### PR TITLE
Add unit tests for ADR and sensitivity

### DIFF
--- a/launcher/tests/test_adr.py
+++ b/launcher/tests/test_adr.py
@@ -1,0 +1,26 @@
+import random
+from launcher.simulator import Simulator
+from launcher.lorawan import TX_POWER_INDEX_TO_DBM
+
+
+def test_adr_ack_delay_adjustment():
+    random.seed(0)
+    sim = Simulator(
+        num_nodes=1,
+        num_gateways=1,
+        transmission_mode="Periodic",
+        packet_interval=1.0,
+        duty_cycle=None,
+        mobility=False,
+        adr_node=True,
+        adr_server=False,
+        fixed_sf=7,
+        fixed_tx_power=2.0,
+        seed=42,
+    )
+    node = sim.nodes[0]
+    for _ in range(1000):
+        node.prepare_uplink(b"test")
+    assert node.sf == 12
+    assert node.tx_power == TX_POWER_INDEX_TO_DBM[0]
+    assert node.adr_ack_cnt == 1000 % (node.adr_ack_limit + node.adr_ack_delay)

--- a/launcher/tests/test_sensitivity.py
+++ b/launcher/tests/test_sensitivity.py
@@ -1,0 +1,8 @@
+import pytest
+from launcher.channel import Channel
+
+
+def test_channel_sensitivity_values():
+    channel = Channel()
+    expected = {7: -123, 8: -126, 9: -129, 10: -132, 11: -134.5, 12: -137}
+    assert channel.sensitivity_dBm == expected


### PR DESCRIPTION
## Summary
- add tests under launcher/tests
- test Channel.sensitivity_dBm for SF7..SF12
- test ADR behavior via Node._check_adr_ack_delay using Simulator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68824cd87b34833187d00027e2528019