### PR TITLE
Add SFRD architecture module

### DIFF
--- a/architecture.py
+++ b/architecture.py
@@ -1,0 +1,77 @@
+from dataclasses import dataclass
+from typing import List, Optional
+
+from launcher.node import Node as _Node
+from launcher.gateway import Gateway as _Gateway
+from launcher.server import NetworkServer as _NetworkServer
+from launcher.config_loader import load_config
+
+
+@dataclass
+class NodeConfig:
+    """Configuration minimale d'un nœud."""
+
+    x: float
+    y: float
+    sf: int = 7
+    tx_power: float = 14.0
+
+
+@dataclass
+class GatewayConfig:
+    """Configuration d'une passerelle."""
+
+    x: float
+    y: float
+    altitude: float = 0.0
+
+
+@dataclass
+class SimulationConfig:
+    """Liste des entités à instancier."""
+
+    nodes: List[NodeConfig]
+    gateways: List[GatewayConfig]
+
+    @classmethod
+    def from_ini(cls, path: str) -> "SimulationConfig":
+        """Charge une configuration INI ou JSON compatible FLoRa."""
+        ndata, gdata = load_config(path)
+        nodes = [NodeConfig(**nd) for nd in ndata]
+        gws = [GatewayConfig(**gw) for gw in gdata]
+        return cls(nodes, gws)
+
+
+class Node(_Node):
+    """Nœud hérité du modèle Python."""
+
+    def __init__(self, node_id: int, cfg: NodeConfig, **kwargs):
+        super().__init__(node_id, cfg.x, cfg.y, cfg.sf, cfg.tx_power, **kwargs)
+
+
+class Gateway(_Gateway):
+    """Passerelle LoRa."""
+
+    def __init__(self, gateway_id: int, cfg: GatewayConfig):
+        super().__init__(gateway_id, cfg.x, cfg.y, cfg.altitude)
+
+
+class NetworkServer(_NetworkServer):
+    """Serveur réseau LoRa."""
+
+    def add_gateway(self, gw: _Gateway) -> None:
+        self.gateways.append(gw)
+
+    def register_node(self, node: _Node) -> None:
+        if node not in self.nodes:
+            self.nodes.append(node)
+
+
+def build_from_config(cfg: SimulationConfig) -> tuple[List[Node], List[Gateway], NetworkServer]:
+    """Instancie nœuds et passerelles selon ``cfg``."""
+    nodes = [Node(i, ncfg) for i, ncfg in enumerate(cfg.nodes)]
+    gws = [Gateway(i, gcfg) for i, gcfg in enumerate(cfg.gateways)]
+    server = NetworkServer()
+    server.nodes = nodes
+    server.gateways = gws
+    return nodes, gws, server


### PR DESCRIPTION
## Summary
- introduce `architecture.py` with Node, Gateway, NetworkServer wrappers
- expose a `SimulationConfig` dataclass loading FLoRa-style INI or JSON files
- keep compatibility with existing launcher modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882513f79308331babc43f52610d7bf