### PR TITLE
Fix periodic interval handling

### DIFF
--- a/run.py
+++ b/run.py
@@ -49,10 +49,11 @@ def simulate(nodes, gateways, mode, interval, steps, channels=1,
     node_gateways = {node: node % max(1, gateways) for node in range(nodes)}
     for node in range(nodes):
         if mode_lower == "periodic":
-            t = 0
+            t = 0.0
             while t < steps:
-                send_times[node].append(t)
+                send_times[node].append(int(round(t)))
                 t += interval
+            send_times[node] = sorted(set(send_times[node]))
         else:  # mode "Random"
             # Émission aléatoire avec probabilité 1/interval à chaque pas de temps
             for t in range(steps):

--- a/tests/test_run_simulate.py
+++ b/tests/test_run_simulate.py
@@ -18,6 +18,19 @@ def test_simulate_single_node_periodic():
     assert throughput == PAYLOAD_SIZE * 8
 
 
+def test_simulate_periodic_float_interval():
+    delivered, collisions, pdr, _, _, _ = simulate(
+        1,
+        1,
+        "Periodic",
+        2.5,
+        10,
+    )
+    assert delivered == 4
+    assert collisions == 0
+    assert pdr == 100.0
+
+
 @pytest.mark.parametrize(
     "nodes, gateways, mode, interval, steps",
     [


### PR DESCRIPTION
## Summary
- handle float intervals correctly in run.simulate
- add regression test for float intervals

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688259d80a8c83319e8fdf134e54738c