### PR TITLE
Add terrain-based mobility model

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ des hauteurs de bâtiments. L'altitude du nœud est alors mise à jour à chaque
 déplacement pour un calcul radio plus réaliste.
 Deux champs « Vitesse min » et « Vitesse max » sont disponibles dans le
 `dashboard` pour définir cette plage avant de lancer la simulation.
+Plusieurs schémas supplémentaires peuvent être utilisés :
+- `RandomWaypoint` gère les déplacements aléatoires en s'appuyant sur une carte
+  de terrain et sur des obstacles dynamiques optionnels.
+- `TerrainMapMobility` permet désormais de suivre une carte rasterisée en
+  pondérant la vitesse par cellule et en tenant compte d'obstacles 3D.
+- `GaussMarkov` et les traces GPS restent disponibles pour modéliser des
+  mouvements plus spécifiques.
 
 ## Multi-canaux
 

--- a/launcher/__init__.py
+++ b/launcher/__init__.py
@@ -10,6 +10,7 @@ from .duty_cycle import DutyCycleManager
 from .smooth_mobility import SmoothMobility
 from .mobility import RandomWaypoint
 from .path_mobility import PathMobility
+from .terrain_mobility import TerrainMapMobility
 from .gauss_markov import GaussMarkov
 from .gps_mobility import GPSTraceMobility, MultiGPSTraceMobility
 from .map_loader import load_map
@@ -31,6 +32,7 @@ __all__ = [
     "SmoothMobility",
     "RandomWaypoint",
     "PathMobility",
+    "TerrainMapMobility",
     "GaussMarkov",
     "GPSTraceMobility",
     "MultiGPSTraceMobility",

--- a/launcher/terrain_mobility.py
+++ b/launcher/terrain_mobility.py
@@ -1,0 +1,163 @@
+import math
+import random
+from typing import List, Tuple
+
+
+class TerrainMapMobility:
+    """Mobility following a raster terrain map with optional 3D obstacles."""
+
+    def __init__(
+        self,
+        area_size: float,
+        terrain: List[List[float]],
+        min_speed: float = 1.0,
+        max_speed: float = 3.0,
+        *,
+        elevation: List[List[float]] | None = None,
+        obstacle_height_map: List[List[float]] | None = None,
+        max_height: float = 0.0,
+    ) -> None:
+        self.area_size = float(area_size)
+        self.terrain = terrain
+        self.min_speed = float(min_speed)
+        self.max_speed = float(max_speed)
+        self.rows = len(terrain)
+        self.cols = len(terrain[0]) if self.rows else 0
+        self.elevation = elevation
+        if elevation:
+            self.e_rows = len(elevation)
+            self.e_cols = len(elevation[0]) if self.e_rows else 0
+        else:
+            self.e_rows = self.e_cols = 0
+        self.obstacle_height_map = obstacle_height_map
+        self.max_height = max_height
+        if obstacle_height_map:
+            self.h_rows = len(obstacle_height_map)
+            self.h_cols = len(obstacle_height_map[0]) if self.h_rows else 0
+        else:
+            self.h_rows = self.h_cols = 0
+
+    # ------------------------------------------------------------------
+    def _speed_factor_cell(self, cx: int, cy: int) -> float:
+        val = float(self.terrain[cy][cx])
+        if val <= 0:
+            return float("inf")
+        return 1.0 / val
+
+    def _height_cell(self, cx: int, cy: int) -> float:
+        if not self.obstacle_height_map or self.h_rows == 0 or self.h_cols == 0:
+            return 0.0
+        hx = int(cx / self.cols * self.h_cols)
+        hy = int(cy / self.rows * self.h_rows)
+        hx = min(max(hx, 0), self.h_cols - 1)
+        hy = min(max(hy, 0), self.h_rows - 1)
+        return float(self.obstacle_height_map[hy][hx])
+
+    def _elevation(self, x: float, y: float) -> float:
+        if not self.elevation or self.e_rows == 0 or self.e_cols == 0:
+            return 0.0
+        cx = int(x / self.area_size * self.e_cols)
+        cy = int(y / self.area_size * self.e_rows)
+        cx = min(max(cx, 0), self.e_cols - 1)
+        cy = min(max(cy, 0), self.e_rows - 1)
+        return float(self.elevation[cy][cx])
+
+    # ------------------------------------------------------------------
+    def _coord_to_cell(self, x: float, y: float) -> Tuple[int, int]:
+        cx = int(x / self.area_size * self.cols)
+        cy = int(y / self.area_size * self.rows)
+        cx = min(max(cx, 0), self.cols - 1)
+        cy = min(max(cy, 0), self.rows - 1)
+        return cx, cy
+
+    def _cell_to_coord(self, cell: Tuple[int, int]) -> Tuple[float, float]:
+        x = (cell[0] + 0.5) / self.cols * self.area_size
+        y = (cell[1] + 0.5) / self.rows * self.area_size
+        return x, y
+
+    def _heuristic(self, a: Tuple[int, int], b: Tuple[int, int]) -> float:
+        return abs(a[0] - b[0]) + abs(a[1] - b[1])
+
+    def _neighbors(self, cell: Tuple[int, int]):
+        x, y = cell
+        for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1)):
+            nx, ny = x + dx, y + dy
+            if 0 <= nx < self.cols and 0 <= ny < self.rows:
+                if self.terrain[ny][nx] > 0:
+                    if self._height_cell(nx, ny) <= self.max_height:
+                        yield nx, ny
+
+    def _find_path(self, start: Tuple[int, int], goal: Tuple[int, int]):
+        open_set = {start}
+        came_from: dict[Tuple[int, int], Tuple[int, int]] = {}
+        g_score = {start: 0.0}
+        f_score = {start: self._heuristic(start, goal)}
+        while open_set:
+            current = min(open_set, key=lambda c: f_score.get(c, float("inf")))
+            if current == goal:
+                cells = [current]
+                while current in came_from:
+                    current = came_from[current]
+                    cells.append(current)
+                cells.reverse()
+                return [self._cell_to_coord(c) for c in cells]
+            open_set.remove(current)
+            for nb in self._neighbors(current):
+                tentative_g = g_score[current] + self._speed_factor_cell(*nb)
+                if tentative_g < g_score.get(nb, float("inf")):
+                    came_from[nb] = current
+                    g_score[nb] = tentative_g
+                    f_score[nb] = tentative_g + self._heuristic(nb, goal)
+                    open_set.add(nb)
+        return []
+
+    def _random_free_cell(self) -> Tuple[int, int]:
+        while True:
+            cx = random.randrange(self.cols)
+            cy = random.randrange(self.rows)
+            if self.terrain[cy][cx] > 0 and self._height_cell(cx, cy) <= self.max_height:
+                return cx, cy
+
+    def _new_path(self, x: float, y: float):
+        start = self._coord_to_cell(x, y)
+        for _ in range(20):
+            goal = self._random_free_cell()
+            path = self._find_path(start, goal)
+            if path:
+                return path
+        return [self._cell_to_coord(start)]
+
+    # ------------------------------------------------------------------
+    def assign(self, node) -> None:
+        node.speed = float(random.uniform(self.min_speed, self.max_speed))
+        node.path = self._new_path(node.x, node.y)
+        node.path_index = 0
+        node.last_move_time = 0.0
+        node.altitude = self._elevation(node.x, node.y)
+
+    def move(self, node, current_time: float) -> None:
+        dt = current_time - node.last_move_time
+        if dt <= 0:
+            return
+        distance = dt * node.speed
+        while distance > 0 and node.path_index < len(node.path) - 1:
+            dest_x, dest_y = node.path[node.path_index + 1]
+            dx = dest_x - node.x
+            dy = dest_y - node.y
+            seg_len = math.hypot(dx, dy)
+            if seg_len == 0:
+                node.path_index += 1
+                continue
+            factor = 1.0 / max(0.1, float(self.terrain[self._coord_to_cell(dest_x, dest_y)[1]][self._coord_to_cell(dest_x, dest_y)[0]]))
+            move = min(distance * factor, seg_len)
+            ratio = move / seg_len
+            node.x += dx * ratio
+            node.y += dy * ratio
+            distance -= move
+            if ratio >= 1.0:
+                node.path_index += 1
+        if node.path_index >= len(node.path) - 1:
+            node.path = self._new_path(node.x, node.y)
+            node.path_index = 0
+        node.altitude = self._elevation(node.x, node.y)
+        node.last_move_time = current_time

--- a/tests/test_terrain_mobility.py
+++ b/tests/test_terrain_mobility.py
@@ -1,0 +1,18 @@
+import random
+from launcher.terrain_mobility import TerrainMapMobility
+from launcher.node import Node
+
+
+def test_terrain_mobility_path_avoids_obstacle():
+    terrain = [
+        [1, -1],
+        [1, 1],
+    ]
+    mobility = TerrainMapMobility(area_size=100.0, terrain=terrain)
+    node = Node(1, 0.0, 0.0, 7, 14)
+    random.seed(0)
+    mobility.assign(node)
+    # Path should not go through cell (1,0) which is an obstacle
+    cells = [mobility._coord_to_cell(x, y) for x, y in node.path]
+    assert (1, 0) not in cells
+


### PR DESCRIPTION
## Summary
- implement `TerrainMapMobility` to move along raster maps with 3D obstacles
- expose the new model via `launcher.__init__`
- document available mobility schemes in README
- test obstacle avoidance for the new mobility model

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68825e0ee2dc833193dd541246b8100d