### PR TITLE
Add dynamic obstacles to PathMobility

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,10 @@ donc continus et sans téléportation.
 Un modèle `PathMobility` permet également de suivre des chemins définis sur une
 grille en évitant les obstacles et peut prendre en compte un relief ainsi que
 des hauteurs de bâtiments. L'altitude du nœud est alors mise à jour à chaque
-déplacement pour un calcul radio plus réaliste.
+déplacement pour un calcul radio plus réaliste. Ce modèle peut désormais lire
+une **carte d'obstacles dynamiques** (fichier JSON) listant les positions,
+rayons et vitesses des objets à éviter. Le tableau de bord propose un champ
+« Carte d’obstacles dynamiques » pour charger ce fichier.
 Deux champs « Vitesse min » et « Vitesse max » sont disponibles dans le
 `dashboard` pour définir cette plage avant de lancer la simulation.
 Plusieurs schémas supplémentaires peuvent être utilisés :

--- a/launcher/dashboard.py
+++ b/launcher/dashboard.py
@@ -188,6 +188,8 @@ ini_file_label = pn.pane.Str("", width=200)
 # Map for path-based mobility
 path_map_input = pn.widgets.FileInput(name="Carte de parcours", accept=".json")
 path_map_label = pn.pane.Str("", width=200)
+dyn_obs_input = pn.widgets.FileInput(name="Carte d'obstacles dynamiques", accept=".json")
+dyn_obs_label = pn.pane.Str("", width=200)
 flora_csv_input = pn.widgets.FileInput(name="CSV FLoRa", accept=".csv")
 flora_csv_label = pn.pane.Str("", width=200)
 
@@ -622,6 +624,15 @@ def setup_simulation(seed_offset: int = 0):
         tmp_map.flush()
         path_map = tmp_map.name
 
+    dyn_map = None
+    if dyn_obs_input.value:
+        import tempfile
+
+        tmp_dyn = tempfile.NamedTemporaryFile(delete=False, suffix=".json")
+        tmp_dyn.write(dyn_obs_input.value.encode())
+        tmp_dyn.flush()
+        dyn_map = tmp_dyn.name
+
     global flora_metrics
     flora_metrics = None
     if flora_csv_input.value:
@@ -665,6 +676,7 @@ def setup_simulation(seed_offset: int = 0):
         min_interference_time=float(min_interference_input.value),
         config_file=config_path,
         path_map=path_map,
+        dynamic_obstacles=dyn_map,
         seed=seed,
     )
 
@@ -1166,12 +1178,17 @@ def on_map_filename(event):
     path_map_label.object = event.new or ""
 
 
+def on_dyn_filename(event):
+    dyn_obs_label.object = event.new or ""
+
+
 def on_csv_filename(event):
     flora_csv_label.object = event.new or ""
 
 
 ini_file_input.param.watch(on_ini_filename, "filename")
 path_map_input.param.watch(on_map_filename, "filename")
+dyn_obs_input.param.watch(on_dyn_filename, "filename")
 flora_csv_input.param.watch(on_csv_filename, "filename")
 
 # --- Boutons ADR ---
@@ -1196,6 +1213,7 @@ controls = pn.WidgetBox(
     num_runs_input,
     pn.Row(ini_file_input, ini_file_label),
     pn.Row(path_map_input, path_map_label),
+    pn.Row(dyn_obs_input, dyn_obs_label),
     pn.Row(flora_csv_input, flora_csv_label),
     adr_node_checkbox,
     adr_server_checkbox,

--- a/launcher/simulator.py
+++ b/launcher/simulator.py
@@ -72,6 +72,7 @@ class Simulator:
                  phy_model: str = "",
                  terrain_map: str | list[list[float]] | None = None,
                  path_map: str | list[list[float]] | None = None,
+                 dynamic_obstacles: str | list[dict] | None = None,
                  beacon_drift: float = 0.0,
                  *,
                  clock_accuracy: float = 0.0,
@@ -128,6 +129,8 @@ class Simulator:
         :param path_map: Carte de type obstacle où un chemin doit être trouvé
             entre deux positions. Lorsque défini, la mobilité suit les
             plus courts chemins évitant les obstacles.
+        :param dynamic_obstacles: Fichier JSON ou liste décrivant des obstacles
+            mouvants pour ``PathMobility``.
         :param beacon_drift: Dérive relative appliquée aux beacons (ppm).
         :param clock_accuracy: Écart-type de la dérive d'horloge des nœuds
             (ppm). Chaque nœud se voit attribuer un décalage aléatoire selon
@@ -177,6 +180,7 @@ class Simulator:
                 path_map,
                 min_speed=mobility_speed[0],
                 max_speed=mobility_speed[1],
+                dynamic_obstacles=dynamic_obstacles,
             )
         elif terrain_map is not None:
             if isinstance(terrain_map, (str, Path)):

--- a/tests/test_path_mobility.py
+++ b/tests/test_path_mobility.py
@@ -1,0 +1,17 @@
+import json
+from launcher.path_mobility import PathMobility
+from launcher.node import Node
+
+def test_dynamic_obstacle_blocks_move(tmp_path):
+    path_map = [[0, 0], [0, 0]]
+    obstacle = [{"x": 50, "y": 50, "radius": 5, "vx": 0, "vy": 0}]
+    obs_file = tmp_path / "obs.json"
+    obs_file.write_text(json.dumps(obstacle))
+    mobility = PathMobility(100.0, path_map, dynamic_obstacles=str(obs_file))
+    node = Node(1, 40.0, 50.0, 7, 14)
+    mobility.assign(node)
+    node.path = [(40.0, 50.0), (50.0, 50.0)]
+    node.speed = 10.0
+    mobility.move(node, 2.0)
+    assert (node.x, node.y) == (40.0, 50.0)
+


### PR DESCRIPTION
## Summary
- support JSON dynamic obstacles in `PathMobility`
- load these obstacles from dashboard and pass to `Simulator`
- document dynamic obstacle files in README
- add regression test for the new feature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882646d12c88331acd96dcbbf1075f9