### PR TITLE
Add FLoRa PHY model

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ réception :
   `(freq, bw, dB)` appliqués au calcul du bruit.
 - `environment` : preset rapide pour le modèle de propagation
   (`urban`, `urban_dense`, `suburban`, `rural`, `indoor` ou `flora`).
+- `phy_model` : "omnet" ou "flora" pour utiliser un modèle physique avancé
+  reprenant les formules de FLoRa.
 
 ```python
 from launcher.channel import Channel

--- a/launcher/flora_phy.py
+++ b/launcher/flora_phy.py
@@ -1,0 +1,59 @@
+"""FLoRa-like physical layer helpers."""
+
+from __future__ import annotations
+
+import math
+import random
+
+
+class FloraPHY:
+    """Replicate FLoRa path loss and capture formulas."""
+
+    NON_ORTH_DELTA = [
+        [1, -8, -9, -9, -9, -9],
+        [-11, 1, -11, -12, -13, -13],
+        [-15, -13, 1, -13, -14, -15],
+        [-19, -18, -17, 1, -17, -18],
+        [-22, -22, -21, -20, 1, -20],
+        [-25, -25, -25, -24, -23, 1],
+    ]
+
+    REFERENCE_DISTANCE = 40.0
+    PATH_LOSS_D0 = 127.41
+
+    def __init__(self, channel) -> None:
+        self.channel = channel
+
+    def path_loss(self, distance: float) -> float:
+        if distance <= 0:
+            return 0.0
+        loss = (
+            self.PATH_LOSS_D0
+            + 10 * self.channel.path_loss_exp
+            * math.log10(max(distance, 1.0) / self.REFERENCE_DISTANCE)
+        )
+        if self.channel.shadowing_std > 0:
+            loss += random.gauss(0.0, self.channel.shadowing_std)
+        return loss + self.channel.system_loss_dB
+
+    def capture(self, rssi_list: list[float], sf_list: list[int]) -> list[bool]:
+        if not rssi_list:
+            return []
+        order = sorted(range(len(rssi_list)), key=lambda i: rssi_list[i], reverse=True)
+        winners = [False] * len(rssi_list)
+        if len(order) == 1:
+            winners[order[0]] = True
+            return winners
+        idx0 = order[0]
+        sf0 = sf_list[idx0]
+        rssi0 = rssi_list[idx0]
+        captured = True
+        for idx in order[1:]:
+            diff = rssi0 - rssi_list[idx]
+            th = self.NON_ORTH_DELTA[sf0 - 7][sf_list[idx] - 7]
+            if diff < th:
+                captured = False
+                break
+        if captured:
+            winners[idx0] = True
+        return winners

--- a/launcher/simulator.py
+++ b/launcher/simulator.py
@@ -121,7 +121,8 @@ class Simulator:
             exécution.
         :param class_c_rx_interval: Période entre deux vérifications de
             downlink pour les nœuds de classe C (s).
-        :param phy_model: "omnet" pour activer le modèle physique OMNeT++.
+        :param phy_model: "omnet" ou "flora" pour activer un modèle physique
+            inspiré de FLoRa.
         :param terrain_map: Carte de terrain utilisée pour la mobilité
             aléatoire (chemin JSON/texte ou matrice). Les valeurs négatives
             indiquent les obstacles et ralentissements éventuels.
@@ -519,9 +520,13 @@ class Simulator:
                     bandwidth=node.channel.bandwidth,
                     noise_floor=node.channel.noise_floor_dBm(),
                     capture_mode=(
-                        "omnet" if node.channel.phy_model == "omnet"
-                        else ("advanced" if node.channel.advanced_capture else "basic")
+                        "omnet" if node.channel.phy_model == "omnet" else (
+                            "flora" if node.channel.phy_model == "flora" else (
+                                "advanced" if node.channel.advanced_capture else "basic"
+                            )
+                        )
                     ),
+                    flora_phy=node.channel.flora_phy if node.channel.phy_model == "flora" else None,
                 )
 
             # Retenir le meilleur RSSI/SNR mesuré pour cette transmission


### PR DESCRIPTION
## Summary
- implement `FloraPHY` for FLoRa path loss and capture formulas
- support new `phy_model="flora"` option in Channel, Simulator and Gateway
- document this option in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882645c7a948331a73e132565875ab8