### PR TITLE
Ajout du module de propagation avancé

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,16 @@ canal = Channel(environment="urban")
 
 Ces valeurs influencent le calcul du RSSI et du SNR retournés par
 `Channel.compute_rssi`.
+Un module **`propagation_models.py`** regroupe des fonctions de perte de parcours log-distance, de shadowing et de fading multipath.
+Il reprend les paramètres des fichiers INI de FLoRa, par exemple `sigma=3.57` pour le preset *flora*.
+
+```python
+from launcher.propagation_models import LogDistanceShadowing, multipath_fading_db
+model = LogDistanceShadowing(environment="flora")
+loss = model.path_loss(1000)
+fad = multipath_fading_db(taps=3)
+```
+
 
 Depuis cette mise à jour, la largeur de bande (`bandwidth`) et le codage
 (`coding_rate`) sont également configurables lors de la création d'un

--- a/launcher/propagation_models.py
+++ b/launcher/propagation_models.py
@@ -1,0 +1,44 @@
+import math
+import random
+
+class LogDistanceShadowing:
+    """Simple log-distance model with log-normal shadowing."""
+
+    ENV_PARAMS = {
+        "urban": (2.7, 6.0),
+        "suburban": (2.3, 4.0),
+        "rural": (2.0, 2.0),
+        "flora": (2.7, 3.57),
+    }
+
+    def __init__(self, frequency_hz: float = 868e6, *, path_loss_exp: float = 2.7,
+                 shadowing_std: float = 6.0, environment: str | None = None) -> None:
+        if environment is not None:
+            env = environment.lower()
+            if env not in self.ENV_PARAMS:
+                raise ValueError(f"Unknown environment: {environment}")
+            path_loss_exp, shadowing_std = self.ENV_PARAMS[env]
+        self.frequency_hz = frequency_hz
+        self.path_loss_exp = path_loss_exp
+        self.shadowing_std = shadowing_std
+
+    def path_loss(self, distance: float) -> float:
+        if distance <= 0:
+            return 0.0
+        freq_mhz = self.frequency_hz / 1e6
+        pl_d0 = 32.45 + 20 * math.log10(freq_mhz) - 60.0
+        loss = pl_d0 + 10 * self.path_loss_exp * math.log10(max(distance, 1.0))
+        if self.shadowing_std > 0:
+            loss += random.gauss(0.0, self.shadowing_std)
+        return loss
+
+
+def multipath_fading_db(taps: int = 1) -> float:
+    """Return a multipath fading value in dB based on Rayleigh paths."""
+    taps = int(taps)
+    if taps <= 1:
+        return 0.0
+    i = sum(random.gauss(0.0, 1.0) for _ in range(taps))
+    q = sum(random.gauss(0.0, 1.0) for _ in range(taps))
+    amp = math.sqrt(i * i + q * q) / math.sqrt(taps)
+    return 20 * math.log10(max(amp, 1e-12))


### PR DESCRIPTION
## Summary
- add `propagation_models` module for log-distance, shadowing and multipath fading
- update README with explanation and example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688268317a9883318361b7a24f2eef11