### PR TITLE
Enhance ADR and downlink scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,8 @@ Les points suivants ont été intégrés au simulateur :
 - **Historique glissant et indicateurs QoS.** Le simulateur calcule désormais le délai moyen de livraison ainsi que le nombre de retransmissions sur la période récente.
 - **Indicateurs supplémentaires.** La méthode `get_metrics()` retourne le PDR par SF, passerelle, classe et nœud. Le tableau de bord affiche un récapitulatif et l'export produit deux fichiers CSV : un pour les événements détaillés et un pour les métriques agrégées.
 - **Moteur d'événements précis.** La file de priorité gère désormais un délai de traitement serveur et la détection des collisions pendant la réception pour se rapprocher du modèle OMNeT++.
+- **Suivi détaillé des ACK.** Chaque nœud mémorise les confirmations reçues pour appliquer fidèlement la logique ADR de FLoRa.
+- **Scheduler de downlinks prioritaire.** Le module `downlink_scheduler.py` organise les transmissions B/C en donnant la priorité aux commandes et accusés de réception.
 
 ## Limites actuelles
 

--- a/launcher/tests/test_adr.py
+++ b/launcher/tests/test_adr.py
@@ -22,5 +22,5 @@ def test_adr_ack_delay_adjustment():
     for _ in range(1000):
         node.prepare_uplink(b"test")
     assert node.sf == 12
-    assert node.tx_power == TX_POWER_INDEX_TO_DBM[0]
+    assert node.tx_power == TX_POWER_INDEX_TO_DBM[1]
     assert node.adr_ack_cnt == 1000 % (node.adr_ack_limit + node.adr_ack_delay)


### PR DESCRIPTION
## Summary
- track ACK history per node
- stepwise ADR tx power adaptation
- allow prioritised downlink scheduling
- use scheduler for class C traffic
- document new features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882686fead88331ac8b85be39e0c1b9