### PR TITLE
Add examples and extension guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,25 @@ Pour suivre les évolutions du projet, consultez le fichier `CHANGELOG.md`.
 
 Ce projet est distribué sous licence [MIT](../LICENSE).
 
+## Exemples complets
+
+Plusieurs scripts sont fournis dans le dossier `examples` pour illustrer
+l'utilisation du simulateur :
+
+```bash
+python examples/run_basic.py          # simulation rapide avec 20 nœuds
+python examples/run_flora_example.py  # reproduction d'un scénario FLoRa
+```
+
+Les utilitaires `analyse_resultats.py` et `analyse_runs.py` aident à traiter les
+fichiers CSV produits par `run.py` ou par le tableau de bord.
+
+## Guide d'extension du dashboard
+
+Le fichier [docs/extension_guide.md](docs/extension_guide.md) détaille comment
+ajouter des options au tableau de bord et intégrer vos propres modules. Ce guide
+vise à faciliter les contributions extérieures.
+
 ## Améliorations possibles
 
 Les points suivants ont été intégrés au simulateur :

--- a/docs/extension_guide.md
+++ b/docs/extension_guide.md
@@ -1,0 +1,42 @@
+# Guide d'extension du tableau de bord
+
+Ce document explique comment personnaliser `launcher/dashboard.py` et ajouter de
+nouvelles fonctionnalit\u00e9s au simulateur.
+
+## Principe g\u00e9n\u00e9ral
+
+Le tableau de bord repose sur [Panel](https://panel.holoviz.org/) pour
+l'affichage et sur `plotly` pour les graphiques. Les options utilisateur sont
+d\u00e9finies dans la classe `SimulatorUI`.
+
+## Ajouter un param\u00e8tre au tableau de bord
+
+1. D\u00e9clarez le nouveau champ dans `SimulatorUI.__init__`.
+2. Passez la valeur au constructeur de `Simulator` dans `launch_sim`.
+3. Mettez \u00e0 jour `update_metrics` pour afficher la m\u00e9trique associ\u00e9e.
+
+Les fonctions existantes illustrent chaque \u00e9tape en d\u00e9tail.
+
+## Int\u00e9grer un module personnalis\u00e9
+
+Vous pouvez remplacer les classes du simulateur pour tester d'autres
+comportements :
+
+```python
+from launcher import Simulator, PathMobility
+
+class MyMobility(PathMobility):
+    def step(self, node, dt):
+        # Impl\u00e9mentation sp\u00e9cifique
+        super().step(node, dt)
+
+sim = Simulator(mobility_model=MyMobility(...))
+```
+
+Les fichiers `gateway.py`, `node.py` et `server.py` peuvent \u00eatre h\u00e9rit\u00e9s pour
+ajouter de nouvelles logiques.
+
+## Conseils aux contributeurs
+
+Avant de proposer une pull request, v\u00e9rifiez que `pytest` s'ex\u00e9cute sans
+\u00e9chec et ajoutez des tests lorsque c'est pertinent.

--- a/examples/analyse_resultats.py
+++ b/examples/analyse_resultats.py
@@ -1,0 +1,23 @@
+import sys
+import pandas as pd
+import matplotlib.pyplot as plt
+
+
+def main(files):
+    data = [pd.read_csv(f) for f in files]
+    df = pd.concat(data, ignore_index=True)
+    by_nodes = df.groupby("nodes")["PDR(%)"].mean()
+    print(by_nodes)
+    by_nodes.plot(marker="o")
+    plt.xlabel("Nombre de n\u0153uds")
+    plt.ylabel("PDR moyen (%)")
+    plt.grid(True)
+    plt.savefig("pdr_par_nodes.png")
+    print("Graphique sauvegard\u00e9 dans pdr_par_nodes.png")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python analyse_resultats.py resultats1.csv [...]")
+    else:
+        main(sys.argv[1:])

--- a/examples/analyse_runs.py
+++ b/examples/analyse_runs.py
@@ -1,0 +1,18 @@
+import sys
+import pandas as pd
+
+
+def main(file):
+    df = pd.read_csv(file)
+    grouped = df.groupby("run").mean(numeric_only=True)
+    print(grouped)
+    out = file.replace(".csv", "_means.csv")
+    grouped.to_csv(out)
+    print(f"Moyennes sauvegard\u00e9es dans {out}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python analyse_runs.py resultats.csv")
+    else:
+        main(sys.argv[1])

--- a/examples/run_basic.py
+++ b/examples/run_basic.py
@@ -1,0 +1,6 @@
+from launcher import Simulator
+
+if __name__ == "__main__":
+    sim = Simulator(num_nodes=20, packet_interval=10, transmission_mode="Random")
+    sim.run(500)
+    print(sim.get_metrics())

--- a/examples/run_flora_example.py
+++ b/examples/run_flora_example.py
@@ -1,0 +1,10 @@
+from launcher import Simulator
+from launcher.adr_standard_1 import apply as adr1
+
+CONFIG = "flora-master/simulations/examples/n100-gw1.ini"
+
+if __name__ == "__main__":
+    sim = Simulator(flora_mode=True, config_file=CONFIG, seed=1)
+    adr1(sim)
+    sim.run(1000)
+    print(sim.get_metrics())


### PR DESCRIPTION
## Summary
- add a folder of runnable examples (`run_basic.py`, `run_flora_example.py`)
- include analysis helpers in `examples`
- document how to extend the dashboard in `docs/extension_guide.md`
- point to the new examples and guide in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688268bdad2c8331b596ab95f0370b16