### PR TITLE
Fix lint errors in architecture

### DIFF
--- a/architecture.py
+++ b/architecture.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List
 
 from launcher.node import Node as _Node
 from launcher.gateway import Gateway as _Gateway

--- a/launcher/tests/test_sensitivity.py
+++ b/launcher/tests/test_sensitivity.py
@@ -1,4 +1,3 @@
-import pytest
 from launcher.channel import Channel
 
 


### PR DESCRIPTION
## Summary
- remove optional import from `architecture`
- drop unused pytest import in tests

## Testing
- `ruff check .`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68826c1a42708331a989b523d9a894d6