### PR TITLE
Fix periodic transmit offset

### DIFF
--- a/run.py
+++ b/run.py
@@ -49,7 +49,8 @@ def simulate(nodes, gateways, mode, interval, steps, channels=1,
     node_gateways = {node: node % max(1, gateways) for node in range(nodes)}
     for node in range(nodes):
         if mode_lower == "periodic":
-            t = 0.0
+            # Randomize the initial offset like the full Simulator
+            t = random.random() * interval
             while t < steps:
                 send_times[node].append(int(round(t)))
                 t += interval


### PR DESCRIPTION
## Summary
- randomize the first send time in `run.py` so periodic runs do not start all nodes at time 0

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882883d18788331b85a18a99205e103