### PR TITLE
Fix RX processing and restore PDR metrics

### DIFF
--- a/launcher/server.py
+++ b/launcher/server.py
@@ -208,6 +208,10 @@ class NetworkServer:
             (at_time if at_time is not None else self.simulator.current_time)
             + self.process_delay
         )
+        if process_time <= self.simulator.current_time:
+            # Pas de délai de traitement -> traiter immédiatement
+            self.receive(event_id, node_id, gateway_id, rssi, frame)
+            return
         from .simulator import Event, EventType
 
         eid = self.simulator.event_id_counter

--- a/launcher/simulator.py
+++ b/launcher/simulator.py
@@ -242,7 +242,8 @@ class Simulator:
 
         # Compatibilité : premier canal par défaut
         self.channel = self.multichannel.channels[0]
-        self.network_server = NetworkServer(simulator=self, process_delay=0.001)
+        # Traiter immédiatement les paquets reçus pour éviter un retard artificiel
+        self.network_server = NetworkServer(simulator=self, process_delay=0.0)
         self.network_server.beacon_interval = self.beacon_interval
         self.network_server.beacon_drift = self.beacon_drift
         self.network_server.ping_slot_interval = self.ping_slot_interval

--- a/tests/test_rx_chain.py
+++ b/tests/test_rx_chain.py
@@ -1,0 +1,35 @@
+import pytest
+from launcher.simulator import Simulator
+
+
+def test_rx_chain_single_node():
+    sim = Simulator(
+        num_nodes=1,
+        num_gateways=1,
+        transmission_mode="Periodic",
+        packet_interval=1.0,
+        packets_to_send=3,
+        mobility=False,
+        seed=0,
+    )
+    sim.run()
+    metrics = sim.get_metrics()
+    assert metrics["PDR"] > 0
+    assert metrics["pdr_by_node"][1] > 0
+
+
+def test_rx_chain_multiple_nodes():
+    sim = Simulator(
+        num_nodes=3,
+        num_gateways=1,
+        transmission_mode="Periodic",
+        packet_interval=1.0,
+        packets_to_send=3,
+        mobility=False,
+        seed=0,
+    )
+    sim.run()
+    metrics = sim.get_metrics()
+    assert metrics["PDR"] > 0
+    for pdr in metrics["pdr_by_node"].values():
+        assert pdr > 0


### PR DESCRIPTION
## Summary
- process uplinks immediately when there is no server delay
- remove the default processing delay in `Simulator` so that packets are counted as soon as they are received
- add regression tests checking that a periodic scenario yields a positive PDR

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68828a29a558833190a158dd8f6acce9