### PR TITLE
Fix line break in extension guide

### DIFF
--- a/docs/extension_guide.md
+++ b/docs/extension_guide.md
@@ -38,5 +38,4 @@ ajouter de nouvelles logiques.
 
 ## Conseils aux contributeurs
 
-Avant de proposer une pull request, v\u00e9rifiez que `pytest` s'ex\u00e9cute sans
-\u00e9chec et ajoutez des tests lorsque c'est pertinent.
+Avant de proposer une pull request, v\u00e9rifiez que `pytest` s'ex\u00e9cute sans \u00e9chec et ajoutez des tests lorsque c'est pertinent.


### PR DESCRIPTION
## Summary
- fix stray newline in `docs/extension_guide.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68828e709c6c8331a3563e316ef1877d