### PR TITLE
Fix misleading schedule_class_c docstring

### DIFF
--- a/launcher/downlink_scheduler.py
+++ b/launcher/downlink_scheduler.py
@@ -63,7 +63,7 @@ class DownlinkScheduler:
         return t
 
     def schedule_class_c(self, node, time: float, frame, gateway, *, priority: int = 0):
-        """Schedule a frame for a Class C node at ``time`` with optional ``priority`` and return it."""
+        """Schedule a frame for a Class C node at ``time`` with optional ``priority`` and return the scheduled time."""
         duration = node.channel.airtime(node.sf, self._payload_length(frame))
         busy = self._gateway_busy.get(gateway.id, 0.0)
         if time < busy:


### PR DESCRIPTION
## Summary
- clarify what `schedule_class_c` returns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68828e884b9083318cad00132468259b