### PR TITLE
Fix gateway SF orthogonality

### DIFF
--- a/launcher/channel.py
+++ b/launcher/channel.py
@@ -91,6 +91,7 @@ class Channel:
         environment: str | None = None,
         region: str | None = None,
         channel_index: int = 0,
+        orthogonal_sf: bool = True,
     ):
         """
         Initialise le canal radio avec paramètres de propagation.
@@ -161,6 +162,8 @@ class Channel:
             la fréquence correspondante du canal ``channel_index``.
         :param channel_index: Index du canal à utiliser dans le plan de la
             région choisie.
+        :param orthogonal_sf: Si ``True``, les transmissions de SF différents
+            n'interfèrent pas entre elles.
         """
 
         if environment is not None:
@@ -261,6 +264,7 @@ class Channel:
         }
         # Seuil de capture (différence de RSSI en dB pour qu'un signal plus fort capture la réception)
         self.capture_threshold_dB = capture_threshold_dB
+        self.orthogonal_sf = orthogonal_sf
 
         if self.phy_model == "omnet":
             from .omnet_phy import OmnetPHY

--- a/launcher/gateway.py
+++ b/launcher/gateway.py
@@ -54,6 +54,7 @@ class Gateway:
         noise_floor: float | None = None,
         capture_mode: str = "basic",
         flora_phy=None,
+        orthogonal_sf: bool = True,
     ):
         """
         Tente de démarrer la réception d'une nouvelle transmission sur cette passerelle.
@@ -73,6 +74,8 @@ class Gateway:
             un calcul basé sur le SNR.
         :param flora_phy: Instance ``FloraPHY`` lorsque ``capture_mode`` vaut
             "flora".
+        :param orthogonal_sf: Si ``True``, les transmissions de SF différents
+            sont ignorées pour la détection de collision.
         """
         key = (sf, frequency)
         concurrent_transmissions = [
@@ -82,6 +85,8 @@ class Gateway:
         # Filtrer les transmissions dont le chevauchement est significatif
         interfering_transmissions = []
         for t in concurrent_transmissions:
+            if orthogonal_sf and t.get('sf') != sf:
+                continue
             overlap = min(t['end_time'], end_time) - current_time
             if overlap > min_interference_time:
                 interfering_transmissions.append(t)

--- a/launcher/simulator.py
+++ b/launcher/simulator.py
@@ -534,6 +534,7 @@ class Simulator:
                         )
                     ),
                     flora_phy=node.channel.flora_phy if node.channel.phy_model == "flora" else None,
+                    orthogonal_sf=node.channel.orthogonal_sf,
                 )
 
             # Retenir le meilleur RSSI/SNR mesuré pour cette transmission

--- a/tests/test_gateway_capture.py
+++ b/tests/test_gateway_capture.py
@@ -1,0 +1,19 @@
+from launcher.gateway import Gateway
+from launcher.server import NetworkServer
+
+
+def test_orthogonal_sf_no_collision():
+    gw = Gateway(0, 0, 0)
+    server = NetworkServer()
+    server.gateways = [gw]
+
+    gw.start_reception(
+        1, 1, 7, -60, 1.0, 6.0, 0.0, 868e6, orthogonal_sf=True
+    )
+    gw.start_reception(
+        2, 2, 9, -60, 1.0, 6.0, 0.0, 868e6, orthogonal_sf=True
+    )
+    gw.end_reception(1, server, 1)
+    gw.end_reception(2, server, 2)
+
+    assert server.packets_received == 2


### PR DESCRIPTION
## Summary
- expose `orthogonal_sf` option in `Channel`
- ignore transmissions with different SF in `Gateway.start_reception`
- pass this option from `Simulator`
- add unit test checking that different SF packets are both received

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68828ea311c88331b3d2ce7c2da64b04