### PR TITLE
Fix missing methods in AdvancedChannel

### DIFF
--- a/launcher/advanced_channel.py
+++ b/launcher/advanced_channel.py
@@ -278,6 +278,18 @@ class AdvancedChannel:
         else:
             self._rows = self._cols = 0
 
+    def __getattr__(self, name: str):
+        """Delegate attribute access to the underlying :class:`Channel`."""
+        return getattr(self.base, name)
+
+    def noise_floor_dBm(self) -> float:
+        """Return the noise floor computed by the base channel."""
+        return self.base.noise_floor_dBm()
+
+    def airtime(self, sf: int, payload_size: int = 20) -> float:
+        """Delegate airtime computation to the base channel."""
+        return self.base.airtime(sf, payload_size)
+
     # ------------------------------------------------------------------
     # Transceiver state helpers
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `__getattr__` to proxy attributes to the base Channel
- implement `airtime` and `noise_floor_dBm` for AdvancedChannel

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882a150ce648331b6933f50ed026c43