### PR TITLE
Remove interval clamping and resample short delays

### DIFF
--- a/launcher/node.py
+++ b/launcher/node.py
@@ -207,6 +207,7 @@ class Node:
         self.snr_history: list[float] = []
         self.in_transmission: bool = False
         self.current_end_time: float | None = None
+        self.last_airtime: float = 0.0
         self.last_rssi: float | None = None
         self.last_snr: float | None = None
         self.downlink_pending: int = 0


### PR DESCRIPTION
## Summary
- follow FLoRa behavior for packet interval generation
- store last airtime on each node
- resample random intervals until longer than previous airtime

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882aa880edc8331ae501483f6e8091c