### PR TITLE
Synchronize timing with FLoRa

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,9 +378,10 @@ Pour des résultats plus proches du terrain, activez `fast_fading_std` et
 `interference_dB` pour introduire un bruit extérieur constant ou variable.
 
 Pour reproduire un scénario FLoRa :
-1. Passez `flora_mode=True` lors de la création du `Simulator` (ou activez
-   **Mode FLoRa complet**). Cela applique un seuil de détection à -110 dBm et une
-   fenêtre d'interférence de 5 s.
+1. Passez `flora_mode=True` et `flora_timing=True` lors de la création du
+   `Simulator` (ou activez **Mode FLoRa complet**). Cela applique un seuil de
+   détection à -110 dBm, une fenêtre d'interférence de 5 s ainsi que les délais
+   réseau de FLoRa.
 2. Appliquez l'algorithme ADR1 via `from launcher.adr_standard_1 import apply as adr1` puis `adr1(sim)`.
    Cette fonction reprend la logique du serveur FLoRa original.
 3. Fournissez le chemin du fichier INI à `Simulator(config_file=...)` ou

--- a/launcher/downlink_scheduler.py
+++ b/launcher/downlink_scheduler.py
@@ -4,11 +4,12 @@ import heapq
 class DownlinkScheduler:
     """Simple scheduler for downlink frames for class B/C nodes."""
 
-    def __init__(self):
+    def __init__(self, link_delay: float = 0.0):
         self.queue: dict[int, list[tuple[float, int, int, object, object]]] = {}
         self._counter = 0
         # Track when each gateway becomes free to transmit
         self._gateway_busy: dict[int, float] = {}
+        self.link_delay = link_delay
 
     @staticmethod
     def _payload_length(frame) -> int:
@@ -58,6 +59,7 @@ class DownlinkScheduler:
         busy = self._gateway_busy.get(gateway.id, 0.0)
         if t < busy:
             t = busy
+        t += self.link_delay
         self.schedule(node.id, t, frame, gateway, priority=priority)
         self._gateway_busy[gateway.id] = t + duration
         return t
@@ -68,6 +70,7 @@ class DownlinkScheduler:
         busy = self._gateway_busy.get(gateway.id, 0.0)
         if time < busy:
             time = busy
+        time += self.link_delay
         self.schedule(node.id, time, frame, gateway, priority=priority)
         self._gateway_busy[gateway.id] = time + duration
         return time
@@ -77,6 +80,7 @@ class DownlinkScheduler:
         from .lorawan import next_beacon_time
 
         t = next_beacon_time(after_time, beacon_interval)
+        t += self.link_delay
         self.schedule(0, t, frame, gateway, priority=priority)
         return t
 

--- a/launcher/server.py
+++ b/launcher/server.py
@@ -22,7 +22,14 @@ MARGIN_DB = 15.0
 class NetworkServer:
     """Représente le serveur de réseau LoRa (collecte des paquets reçus)."""
 
-    def __init__(self, join_server=None, *, simulator=None, process_delay: float = 0.0):
+    def __init__(
+        self,
+        join_server=None,
+        *,
+        simulator=None,
+        process_delay: float = 0.0,
+        network_delay: float = 0.0,
+    ):
         """Initialise le serveur réseau.
 
         :param join_server: Instance facultative de serveur d'activation OTAA.
@@ -45,10 +52,11 @@ class NetworkServer:
         self.channel = None
         self.net_id = 0
         self.next_devaddr = 1
-        self.scheduler = DownlinkScheduler()
+        self.scheduler = DownlinkScheduler(link_delay=network_delay)
         self.join_server = join_server
         self.simulator = simulator
         self.process_delay = process_delay
+        self.network_delay = network_delay
         self.pending_process: dict[int, tuple[int, int, int, float | None, object]] = {}
         self.beacon_interval = 128.0
         self.beacon_drift = 0.0
@@ -206,6 +214,7 @@ class NetworkServer:
             return
         process_time = (
             (at_time if at_time is not None else self.simulator.current_time)
+            + self.network_delay
             + self.process_delay
         )
         if process_time <= self.simulator.current_time:

--- a/launcher/simulator.py
+++ b/launcher/simulator.py
@@ -68,6 +68,7 @@ class Simulator:
                  detection_threshold_dBm: float = -float("inf"),
                  min_interference_time: float = 0.0,
                  flora_mode: bool = False,
+                 flora_timing: bool = False,
                  config_file: str | None = None,
                  seed: int | None = None,
                  class_c_rx_interval: float = 1.0,
@@ -118,6 +119,8 @@ class Simulator:
             transmissions avant de les considérer en collision (s).
         :param flora_mode: Active automatiquement les réglages du mode FLoRa
             complet (seuil -110 dBm et 5 s d'interférence minimale).
+        :param flora_timing: Utilise les temporisations du projet FLoRa
+            (délai réseau de 10 ms et traitement serveur de 1,2 s).
         :param config_file: Fichier INI listant les positions des nœuds et
             passerelles à charger. Lorsque défini, ``num_nodes`` et
             ``num_gateways`` sont ignorés.
@@ -174,6 +177,7 @@ class Simulator:
         self.detection_threshold_dBm = detection_threshold_dBm
         self.min_interference_time = min_interference_time
         self.flora_mode = flora_mode
+        self.flora_timing = flora_timing
         self.config_file = config_file
         self.phy_model = phy_model
         # Activation ou non de la mobilité des nœuds
@@ -252,8 +256,19 @@ class Simulator:
 
         # Compatibilité : premier canal par défaut
         self.channel = self.multichannel.channels[0]
+        # Réglages de temporisation inspirés de FLoRa
+        if flora_timing:
+            proc_delay = 1.2
+            net_delay = 0.01
+        else:
+            proc_delay = 0.0
+            net_delay = 0.0
         # Traiter immédiatement les paquets reçus pour éviter un retard artificiel
-        self.network_server = NetworkServer(simulator=self, process_delay=0.0)
+        self.network_server = NetworkServer(
+            simulator=self,
+            process_delay=proc_delay,
+            network_delay=net_delay,
+        )
         self.network_server.beacon_interval = self.beacon_interval
         self.network_server.beacon_drift = self.beacon_drift
         self.network_server.ping_slot_interval = self.ping_slot_interval


### PR DESCRIPTION
## Summary
- propagate FLoRa timing defaults from example configs
- add network delay to server and scheduler
- expose new `flora_timing` option in `Simulator`
- document the option in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882aac213048331897b588d231aab7e