### PR TITLE
Align ADR SNR computation with FLoRa

### DIFF
--- a/launcher/server.py
+++ b/launcher/server.py
@@ -29,12 +29,17 @@ class NetworkServer:
         simulator=None,
         process_delay: float = 0.0,
         network_delay: float = 0.0,
+        adr_method: str = "max",
     ):
         """Initialise le serveur réseau.
 
         :param join_server: Instance facultative de serveur d'activation OTAA.
         :param simulator: Référence au :class:`Simulator` pour planifier
             éventuellement certains événements (classe C).
+        :param process_delay: Délai de traitement du serveur (s).
+        :param network_delay: Délai de propagation des messages (s).
+        :param adr_method: Méthode d'agrégation du SNR pour l'ADR
+            (``"max"`` ou ``"avg"``).
         """
         # Ensemble des identifiants d'événements déjà reçus (pour éviter les doublons)
         self.received_events = set()
@@ -57,6 +62,7 @@ class NetworkServer:
         self.simulator = simulator
         self.process_delay = process_delay
         self.network_delay = network_delay
+        self.adr_method = adr_method
         self.pending_process: dict[int, tuple[int, int, int, float | None, object]] = {}
         self.beacon_interval = 128.0
         self.beacon_drift = 0.0
@@ -350,9 +356,12 @@ class NetworkServer:
                 if len(node.snr_history) > 20:
                     node.snr_history.pop(0)
                 if len(node.snr_history) >= 20:
-                    max_snr = max(node.snr_history)
+                    if self.adr_method == "avg":
+                        snr_m = sum(node.snr_history) / len(node.snr_history)
+                    else:
+                        snr_m = max(node.snr_history)
                     required = REQUIRED_SNR.get(node.sf, -20.0)
-                    margin = max_snr - required - MARGIN_DB
+                    margin = snr_m - required - MARGIN_DB
                     nstep = round(margin / 3.0)
 
                     sf = node.sf

--- a/launcher/simulator.py
+++ b/launcher/simulator.py
@@ -57,6 +57,7 @@ class Simulator:
                  transmission_mode: str = 'Random', packet_interval: float = 60.0,
                  interval_variation: float = 0.0,
                  packets_to_send: int = 0, adr_node: bool = False, adr_server: bool = False,
+                 adr_method: str = "max",
                  duty_cycle: float | None = 0.01, mobility: bool = True,
                  channels=None, channel_distribution: str = "round-robin",
                  mobility_speed: tuple[float, float] = (2.0, 10.0),
@@ -98,6 +99,8 @@ class Simulator:
             d'arrêter la simulation (0 = infini).
         :param adr_node: Activation de l'ADR côté nœud.
         :param adr_server: Activation de l'ADR côté serveur.
+        :param adr_method: Méthode d'agrégation du SNR pour l'ADR
+            (``"max"`` ou ``"avg"``).
         :param duty_cycle: Facteur de duty cycle (ex: 0.01 pour 1 %). Par
             défaut à 0.01. Si None, le duty cycle est désactivé.
         :param mobility: Active la mobilité aléatoire des nœuds lorsqu'il est
@@ -164,6 +167,7 @@ class Simulator:
         self.packets_to_send = packets_to_send
         self.adr_node = adr_node
         self.adr_server = adr_server
+        self.adr_method = adr_method
         self.fixed_sf = fixed_sf
         self.fixed_tx_power = fixed_tx_power
         self.battery_capacity_j = battery_capacity_j
@@ -268,6 +272,7 @@ class Simulator:
             simulator=self,
             process_delay=proc_delay,
             network_delay=net_delay,
+            adr_method=self.adr_method,
         )
         self.network_server.beacon_interval = self.beacon_interval
         self.network_server.beacon_drift = self.beacon_drift


### PR DESCRIPTION
## Summary
- add configurable `adr_method` to `NetworkServer` and `Simulator`
- compute aggregated SNR by average or max depending on configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882ad948dc48331b0671c7f2bda8821