### PR TITLE
Fix example scripts import path

### DIFF
--- a/examples/run_basic.py
+++ b/examples/run_basic.py
@@ -1,3 +1,11 @@
+"""Exemple basique de simulation LoRa."""
+
+import os
+import sys
+
+# Ajoute le répertoire parent pour pouvoir importer ``launcher``
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 from launcher import Simulator
 
 if __name__ == "__main__":

--- a/examples/run_flora_example.py
+++ b/examples/run_flora_example.py
@@ -1,3 +1,11 @@
+"""Exécution d'un scénario FLoRa prêt à l'emploi."""
+
+import os
+import sys
+
+# Ajoute le répertoire parent pour résoudre les imports du package ``launcher``
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 from launcher import Simulator
 from launcher.adr_standard_1 import apply as adr1
 


### PR DESCRIPTION
## Summary
- fix `run_basic.py` and `run_flora_example.py` so they can be executed directly

## Testing
- `pytest -q`
- `python examples/run_basic.py`

------
https://chatgpt.com/codex/tasks/task_e_6882b50209a0833182c24983bd9c6cd1