### PR TITLE
Add scheduler and mobility unit tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import random
+import pytest
+
+@pytest.fixture(autouse=True)
+def _set_seed():
+    random.seed(1)

--- a/tests/test_class_bc.py
+++ b/tests/test_class_bc.py
@@ -1,0 +1,41 @@
+import math
+from launcher.downlink_scheduler import DownlinkScheduler
+from launcher.gateway import Gateway
+from launcher.node import Node
+
+
+def test_schedule_beacon_time():
+    scheduler = DownlinkScheduler()
+    gw = Gateway(1, 0, 0)
+    t = scheduler.schedule_beacon(62.0, b"x", gw, beacon_interval=10.0)
+    assert math.isclose(t, 70.0)
+    frame, gw2 = scheduler.pop_ready(0, 70.0)
+    assert frame == b"x" and gw2 is gw
+
+
+def test_schedule_class_b():
+    scheduler = DownlinkScheduler()
+    gw = Gateway(1, 0, 0)
+    node = Node(1, 0.0, 0.0, 7, 14, class_type="B")
+    t = scheduler.schedule_class_b(
+        node,
+        0.0,
+        b"a",
+        gw,
+        beacon_interval=128.0,
+        ping_slot_interval=1.0,
+        ping_slot_offset=2.0,
+    )
+    assert math.isclose(t, 2.0)
+    frame, gw2 = scheduler.pop_ready(node.id, t)
+    assert frame == b"a" and gw2 is gw
+
+
+def test_schedule_class_c_delay():
+    scheduler = DownlinkScheduler(link_delay=0.5)
+    gw = Gateway(1, 0, 0)
+    node = Node(1, 0.0, 0.0, 7, 14, class_type="C")
+    t = scheduler.schedule_class_c(node, 1.0, b"b", gw)
+    assert math.isclose(t, 1.5)
+    frame, gw2 = scheduler.pop_ready(node.id, t)
+    assert frame == b"b" and gw2 is gw

--- a/tests/test_mobility_extra.py
+++ b/tests/test_mobility_extra.py
@@ -1,0 +1,33 @@
+from launcher.path_mobility import PathMobility
+from launcher.terrain_mobility import TerrainMapMobility
+from launcher.node import Node
+
+
+def test_path_mobility_altitude_update():
+    path_map = [[0, 0], [0, 0]]
+    elevation = [[0, 10], [0, 0]]
+    mobility = PathMobility(area_size=100.0, path_map=path_map, elevation=elevation)
+    node = Node(1, 0.0, 0.0, 7, 14)
+    start = mobility._cell_to_coord((0, 0))
+    dest = mobility._cell_to_coord((1, 0))
+    node.x, node.y = start
+    node.path = [start, dest]
+    node.speed = 50.0
+    mobility.move(node, 1.0)
+    assert node.altitude == 10.0
+    assert (node.x, node.y) == dest
+
+
+def test_terrain_mobility_speed_factor():
+    terrain = [[1, 1]]
+    mobility = TerrainMapMobility(area_size=100.0, terrain=terrain)
+    node = Node(1, 0.0, 50.0, 7, 14)
+    start = mobility._cell_to_coord((0, 0))
+    dest = mobility._cell_to_coord((1, 0))
+    node.x, node.y = start
+    node.path = [start, dest]
+    node.speed = 10.0
+    mobility.move(node, 1.0)
+    assert node.x == 35.0
+    assert node.y == start[1]
+


### PR DESCRIPTION
## Summary
- add class B/C scheduler tests
- add mobility tests for altitude and speed factor
- seed Python's RNG for deterministic tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882b84aa6fc8331b6031b363b042f71