### PR TITLE
Fix collision handling in simple simulator

### DIFF
--- a/run.py
+++ b/run.py
@@ -108,9 +108,10 @@ def simulate(nodes, gateways, mode, interval, steps, channels=1,
                                 logging.debug(
                                     f"t={t} Node {n} GW {gw} CH {ch} rejeté (bruit)"
                                 )
-                                diag_logger.info(
-                                    f"t={t} gw={gw} ch={ch} collision=[{n}] cause=noise"
-                                )
+                            diag_logger.info(
+                                f"t={t} gw={gw} ch={ch} collision=[{n}] cause=noise"
+                            )
+                            del pending[n]
                     else:
                         winner = random.choice(nodes_on_ch)
                         success = True
@@ -136,6 +137,9 @@ def simulate(nodes, gateways, mode, interval, steps, channels=1,
                             diag_logger.info(
                                 f"t={t} gw={gw} ch={ch} collision={nodes_on_ch} winner={winner}"
                             )
+                            for n in nodes_on_ch:
+                                if n != winner and n in pending:
+                                    del pending[n]
                         else:
                             collisions += nb_tx
                             if debug_rx:
@@ -146,6 +150,9 @@ def simulate(nodes, gateways, mode, interval, steps, channels=1,
                             diag_logger.info(
                                 f"t={t} gw={gw} ch={ch} collision={nodes_on_ch} none"
                             )
+                            for n in nodes_on_ch:
+                                if n in pending:
+                                    del pending[n]
 
     # Calcul des métriques finales
     pdr = (

--- a/tests/test_run_simulate.py
+++ b/tests/test_run_simulate.py
@@ -47,3 +47,20 @@ def test_simulate_periodic_float_interval():
 def test_simulate_invalid_parameters(nodes, gateways, mode, interval, steps):
     with pytest.raises(ValueError):
         simulate(nodes, gateways, mode, interval, steps)
+
+
+def test_simulate_collision():
+    """Packets lost in a collision should not be retried indefinitely."""
+    random.seed(0)
+    delivered, collisions, pdr, energy, avg_delay, throughput = simulate(
+        2,
+        1,
+        "Periodic",
+        1,
+        3,
+    )
+    assert delivered == 2
+    assert collisions == 2
+    assert energy == 4.0
+    assert avg_delay == 0
+    assert throughput == PAYLOAD_SIZE * 8 * delivered / 3


### PR DESCRIPTION
## Summary
- drop pending packets after failed reception to avoid infinite retries
- update corresponding tests
- add regression test for collision scenario

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882c00f0fc08331b20bb57e84d3bdf2