### PR TITLE
Fix zero-length segment in PathMobility

### DIFF
--- a/simulateur_lora_sfrd/launcher/path_mobility.py
+++ b/simulateur_lora_sfrd/launcher/path_mobility.py
@@ -173,6 +173,9 @@ class PathMobility:
             dx = dest_x - node.x
             dy = dest_y - node.y
             seg_len = math.hypot(dx, dy)
+            if seg_len == 0:
+                node.path_index += 1
+                continue
             if distance >= seg_len:
                 new_x, new_y = dest_x, dest_y
                 move_len = seg_len


### PR DESCRIPTION
## Summary
- handle zero-length segments when moving along a path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882c70251c883318803389ce30d5a4d