### PR TITLE
Update Gateway docstring

### DIFF
--- a/simulateur_lora_sfrd/launcher/gateway.py
+++ b/simulateur_lora_sfrd/launcher/gateway.py
@@ -19,11 +19,14 @@ class Gateway:
         """
         Initialise une passerelle LoRa.
 
+        ``rx_gain_dB`` correspond au gain d'antenne supplémentaire appliqué
+        au signal reçu.
+
         :param gateway_id: Identifiant de la passerelle.
         :param x: Position X (mètres).
         :param y: Position Y (mètres).
         :param altitude: Altitude de l'antenne (mètres).
-        :param rx_gain_dB: Gain/rayon de couverture additionnel (dB).
+        :param rx_gain_dB: Gain d’antenne additionnel (dB).
         """
         self.id = gateway_id
         self.x = x


### PR DESCRIPTION
## Summary
- clarify `Gateway.__init__` docstring regarding `rx_gain_dB`
- use correct French wording for the antenna gain parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882c706ea1c833197947b6167e97034