### PR TITLE
Add RandomWaypoint path planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ Deux champs « Vitesse min » et « Vitesse max » sont disponibles dans
 Plusieurs schémas supplémentaires peuvent être utilisés :
 - `RandomWaypoint` gère les déplacements aléatoires en s'appuyant sur une carte
   de terrain et sur des obstacles dynamiques optionnels.
+- `PlannedRandomWaypoint` applique la même logique mais choisit un point d'arrivée
+  aléatoire puis planifie un chemin en A* pour contourner un relief 3D ou des
+  obstacles fixes.
 - `TerrainMapMobility` permet désormais de suivre une carte rasterisée en
   pondérant la vitesse par cellule et en tenant compte d'obstacles 3D.
 - `GaussMarkov` et les traces GPS restent disponibles pour modéliser des
@@ -495,7 +498,7 @@ encore de maturité :
 
 - La couche physique est simplifiée et n'imite pas parfaitement les comportements
   réels des modems LoRa.
-- La mobilité par défaut s'appuie sur des trajets de Bézier. Un modèle RandomWaypoint peut exploiter une carte de terrain pour éviter les obstacles. Un module de navigation peut désormais planifier des chemins à partir d'une carte d'obstacles.
+- La mobilité par défaut s'appuie sur des trajets de Bézier. Un modèle RandomWaypoint et son planificateur A* permettent d'éviter relief et obstacles 3D.
 - La sécurité LoRaWAN s'appuie désormais sur un chiffrement AES-128 complet et la validation du MIC. Le serveur de jointure gère l'ensemble de la procédure OTAA.
 
 Les contributions sont les bienvenues pour lever ces limitations ou proposer de

--- a/simulateur_lora_sfrd/launcher/__init__.py
+++ b/simulateur_lora_sfrd/launcher/__init__.py
@@ -9,6 +9,7 @@ from .simulator import Simulator
 from .duty_cycle import DutyCycleManager
 from .smooth_mobility import SmoothMobility
 from .random_waypoint import RandomWaypoint
+from .planned_random_waypoint import PlannedRandomWaypoint
 from .path_mobility import PathMobility
 from .terrain_mobility import TerrainMapMobility
 from .gauss_markov import GaussMarkov
@@ -31,6 +32,7 @@ __all__ = [
     "DutyCycleManager",
     "SmoothMobility",
     "RandomWaypoint",
+    "PlannedRandomWaypoint",
     "PathMobility",
     "TerrainMapMobility",
     "GaussMarkov",

--- a/simulateur_lora_sfrd/launcher/planned_random_waypoint.py
+++ b/simulateur_lora_sfrd/launcher/planned_random_waypoint.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+from typing import Iterable, List
+import random
+import math
+
+from .waypoint_planner import WaypointPlanner3D
+from .map_loader import load_map
+
+
+class PlannedRandomWaypoint:
+    """Random waypoint mobility using a 3D path planner."""
+
+    def __init__(
+        self,
+        area_size: float,
+        min_speed: float = 1.0,
+        max_speed: float = 3.0,
+        *,
+        terrain: str | Path | Iterable[Iterable[float]] | None = None,
+        elevation: str | Path | Iterable[Iterable[float]] | None = None,
+        obstacle_height_map: str | Path | Iterable[Iterable[float]] | None = None,
+        max_height: float = 0.0,
+        slope_scale: float = 0.1,
+    ) -> None:
+        if terrain is None:
+            raise ValueError("terrain map is required for planned random waypoint")
+        if isinstance(terrain, (str, Path)):
+            terrain = load_map(terrain)
+        if elevation is not None and isinstance(elevation, (str, Path)):
+            elevation = load_map(elevation)
+        if obstacle_height_map is not None and isinstance(obstacle_height_map, (str, Path)):
+            obstacle_height_map = load_map(obstacle_height_map)
+        self.planner = WaypointPlanner3D(
+            area_size,
+            terrain,
+            elevation=elevation,
+            obstacle_height_map=obstacle_height_map,
+            max_height=max_height,
+            slope_scale=slope_scale,
+        )
+        self.area_size = float(area_size)
+        self.min_speed = float(min_speed)
+        self.max_speed = float(max_speed)
+
+    # --------------------------------------------------------------
+    def assign(self, node) -> None:
+        node.speed = float(random.uniform(self.min_speed, self.max_speed))
+        goal = self.planner.random_free_point()
+        node.path = self.planner.find_path((node.x, node.y), goal)
+        node.path_index = 0
+        node.last_move_time = 0.0
+        node.altitude = self.planner.elevation_at(node.x, node.y)
+
+    def move(self, node, current_time: float) -> None:
+        dt = current_time - node.last_move_time
+        if dt <= 0:
+            return
+        distance = dt * node.speed
+        while distance > 0 and node.path_index < len(node.path) - 1:
+            dest_x, dest_y = node.path[node.path_index + 1]
+            dx = dest_x - node.x
+            dy = dest_y - node.y
+            seg_len = math.hypot(dx, dy)
+            if seg_len == 0:
+                node.path_index += 1
+                continue
+            move = min(distance, seg_len)
+            ratio = move / seg_len
+            node.x += dx * ratio
+            node.y += dy * ratio
+            distance -= move
+            if ratio >= 1.0:
+                node.path_index += 1
+        if node.path_index >= len(node.path) - 1:
+            goal = self.planner.random_free_point()
+            node.path = self.planner.find_path((node.x, node.y), goal)
+            node.path_index = 0
+        node.altitude = self.planner.elevation_at(node.x, node.y)
+        node.last_move_time = current_time

--- a/simulateur_lora_sfrd/launcher/waypoint_planner.py
+++ b/simulateur_lora_sfrd/launcher/waypoint_planner.py
@@ -1,0 +1,148 @@
+# Path planner using A* over a terrain map with optional elevation and 3D obstacles.
+import math
+import random
+from typing import Iterable, List, Tuple
+
+
+class WaypointPlanner3D:
+    """A* planner avoiding obstacles and high buildings."""
+
+    def __init__(
+        self,
+        area_size: float,
+        terrain: List[List[float]],
+        *,
+        elevation: List[List[float]] | None = None,
+        obstacle_height_map: List[List[float]] | None = None,
+        max_height: float = 0.0,
+        slope_scale: float = 0.1,
+    ) -> None:
+        self.area_size = float(area_size)
+        self.terrain = terrain
+        self.rows = len(terrain)
+        self.cols = len(terrain[0]) if self.rows else 0
+        self.elevation = elevation
+        if elevation:
+            self.e_rows = len(elevation)
+            self.e_cols = len(elevation[0]) if self.e_rows else 0
+        else:
+            self.e_rows = self.e_cols = 0
+        self.obstacle_height_map = obstacle_height_map
+        self.max_height = max_height
+        if obstacle_height_map:
+            self.h_rows = len(obstacle_height_map)
+            self.h_cols = len(obstacle_height_map[0]) if self.h_rows else 0
+        else:
+            self.h_rows = self.h_cols = 0
+        self.slope_scale = slope_scale
+
+    # --------------------------------------------------------------
+    def _terrain_factor_cell(self, cx: int, cy: int) -> float | None:
+        val = float(self.terrain[cy][cx])
+        if val < 0:
+            return None
+        return val if val > 0 else 1.0
+
+    def _height_cell(self, cx: int, cy: int) -> float:
+        if not self.obstacle_height_map or self.h_rows == 0 or self.h_cols == 0:
+            return 0.0
+        hx = int(cx / self.cols * self.h_cols)
+        hy = int(cy / self.rows * self.h_rows)
+        hx = min(max(hx, 0), self.h_cols - 1)
+        hy = min(max(hy, 0), self.h_rows - 1)
+        return float(self.obstacle_height_map[hy][hx])
+
+    def _elevation_cell(self, cx: int, cy: int) -> float:
+        if not self.elevation or self.e_rows == 0 or self.e_cols == 0:
+            return 0.0
+        ex = int(cx / self.cols * self.e_cols)
+        ey = int(cy / self.rows * self.e_rows)
+        ex = min(max(ex, 0), self.e_cols - 1)
+        ey = min(max(ey, 0), self.e_rows - 1)
+        return float(self.elevation[ey][ex])
+
+    def _coord_to_cell(self, x: float, y: float) -> Tuple[int, int]:
+        cx = int(x / self.area_size * self.cols)
+        cy = int(y / self.area_size * self.rows)
+        cx = min(max(cx, 0), self.cols - 1)
+        cy = min(max(cy, 0), self.rows - 1)
+        return cx, cy
+
+    def _cell_to_coord(self, cell: Tuple[int, int]) -> Tuple[float, float]:
+        x = (cell[0] + 0.5) / self.cols * self.area_size
+        y = (cell[1] + 0.5) / self.rows * self.area_size
+        return x, y
+
+    # --------------------------------------------------------------
+    def _neighbors(self, cell: Tuple[int, int]):
+        x, y = cell
+        for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1)):
+            nx, ny = x + dx, y + dy
+            if 0 <= nx < self.cols and 0 <= ny < self.rows:
+                if self._terrain_factor_cell(nx, ny) is not None:
+                    if self._height_cell(nx, ny) <= self.max_height:
+                        yield nx, ny
+
+    def _heuristic(self, a: Tuple[int, int], b: Tuple[int, int]) -> float:
+        return abs(a[0] - b[0]) + abs(a[1] - b[1])
+
+    def _cost(self, a: Tuple[int, int], b: Tuple[int, int]) -> float:
+        factor = self._terrain_factor_cell(b[0], b[1])
+        if factor is None:
+            return float("inf")
+        cost = 1.0 / factor
+        if self.elevation:
+            alt_a = self._elevation_cell(*a)
+            alt_b = self._elevation_cell(*b)
+            dist = math.hypot(b[0] - a[0], b[1] - a[1])
+            if dist > 0:
+                slope = (alt_b - alt_a) / dist
+                if slope > 0:
+                    cost *= 1.0 + slope * self.slope_scale
+        return cost
+
+    # --------------------------------------------------------------
+    def find_path(
+        self, start: Tuple[float, float], goal: Tuple[float, float]
+    ) -> List[Tuple[float, float]]:
+        s = self._coord_to_cell(*start)
+        g = self._coord_to_cell(*goal)
+        open_set = {s}
+        came_from: dict[Tuple[int, int], Tuple[int, int]] = {}
+        g_score = {s: 0.0}
+        f_score = {s: self._heuristic(s, g)}
+        while open_set:
+            current = min(open_set, key=lambda c: f_score.get(c, float("inf")))
+            if current == g:
+                cells = [current]
+                while current in came_from:
+                    current = came_from[current]
+                    cells.append(current)
+                cells.reverse()
+                return [self._cell_to_coord(c) for c in cells]
+            open_set.remove(current)
+            for nb in self._neighbors(current):
+                tentative_g = g_score[current] + self._cost(current, nb)
+                if tentative_g < g_score.get(nb, float("inf")):
+                    came_from[nb] = current
+                    g_score[nb] = tentative_g
+                    f_score[nb] = tentative_g + self._heuristic(nb, g)
+                    open_set.add(nb)
+        return [start, goal]
+
+    def random_free_point(self) -> Tuple[float, float]:
+        while True:
+            cx = random.randrange(self.cols)
+            cy = random.randrange(self.rows)
+            if self._terrain_factor_cell(cx, cy) is not None:
+                if self._height_cell(cx, cy) <= self.max_height:
+                    return self._cell_to_coord((cx, cy))
+
+    def elevation_at(self, x: float, y: float) -> float:
+        if not self.elevation:
+            return 0.0
+        cx = int(x / self.area_size * self.e_cols)
+        cy = int(y / self.area_size * self.e_rows)
+        cx = min(max(cx, 0), self.e_cols - 1)
+        cy = min(max(cy, 0), self.e_rows - 1)
+        return float(self.elevation[cy][cx])

--- a/tests/test_planned_random_waypoint.py
+++ b/tests/test_planned_random_waypoint.py
@@ -1,0 +1,33 @@
+from simulateur_lora_sfrd.launcher.planned_random_waypoint import PlannedRandomWaypoint
+from simulateur_lora_sfrd.launcher.node import Node
+
+
+def test_planner_avoids_high_obstacle():
+    terrain = [
+        [1, 1, 1],
+        [1, 1, 1],
+        [1, 1, 1],
+    ]
+    heights = [
+        [0, 0, 0],
+        [0, 10, 0],
+        [0, 0, 0],
+    ]
+    mobility = PlannedRandomWaypoint(
+        area_size=90.0,
+        terrain=terrain,
+        obstacle_height_map=heights,
+        max_height=5,
+    )
+    node = Node(1, 0.0, 0.0, 7, 14)
+    mobility.assign(node)
+    cells = [mobility.planner._coord_to_cell(x, y) for x, y in node.path]
+    assert (1, 1) not in cells
+
+
+def test_assign_sets_path():
+    terrain = [[1, 1], [1, 1]]
+    mobility = PlannedRandomWaypoint(area_size=20.0, terrain=terrain)
+    node = Node(1, 5.0, 5.0, 7, 14)
+    mobility.assign(node)
+    assert len(node.path) >= 2


### PR DESCRIPTION
## Summary
- add `WaypointPlanner3D` and `PlannedRandomWaypoint` classes
- expose the new mobility in `__init__.py`
- document new 3D random waypoint mobility
- add unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882c8dbe4748331b3aa037a7cb48ebd