### PR TITLE
Add test for FLoRa example

### DIFF
--- a/tests/data/n100_gw1_expected.csv
+++ b/tests/data/n100_gw1_expected.csv
@@ -1,0 +1,2 @@
+sent,received,sf7,sf8,sf9,sf10,sf11,sf12
+10,10,0,0,0,0,0,10

--- a/tests/test_flora_example.py
+++ b/tests/test_flora_example.py
@@ -1,0 +1,16 @@
+import runpy
+from pathlib import Path
+
+import pytest
+
+from simulateur_lora_sfrd.launcher.compare_flora import compare_with_sim
+
+
+def test_flora_example_matches_flora():
+    pytest.importorskip('pandas')
+    # Execute the example script as if run directly
+    globals_dict = runpy.run_path('examples/run_flora_example.py', run_name='__main__')
+    sim = globals_dict['sim']
+    metrics = sim.get_metrics()
+    flora_csv = Path(__file__).parent / 'data' / 'n100_gw1_expected.csv'
+    assert compare_with_sim(metrics, flora_csv)


### PR DESCRIPTION
## Summary
- add fixture data for the FLoRa n100-gw1 scenario
- create `test_flora_example` using the example script and compare_flora

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883573c644883318fb7bbd798e680b2