### PR TITLE
Enable average SNR for ADR1

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,11 +398,13 @@ Pour reproduire un scénario FLoRa :
    réseau de 10 ms et un traitement serveur de 1,2 s comme dans OMNeT++.
 2. Appliquez l'algorithme ADR1 via `from simulateur_lora_sfrd.launcher.adr_standard_1 import apply as adr1` puis `adr1(sim)`.
    Cette fonction reprend la logique du serveur FLoRa original.
-3. Fournissez le chemin du fichier INI à `Simulator(config_file=...)` ou
+3. Spécifiez `adr_method="avg"` lors de la création du `Simulator` (ou sur
+   `sim.network_server`) pour utiliser la moyenne des 20 derniers SNR.
+4. Fournissez le chemin du fichier INI à `Simulator(config_file=...)` ou
    saisissez les coordonnées manuellement via **Positions manuelles**.
-4. Renseignez **Graine** pour conserver exactement le même placement d'une
+5. Renseignez **Graine** pour conserver exactement le même placement d'une
    exécution à l'autre.
-5. Ou lancez `python examples/run_flora_example.py` qui combine ces réglages.
+6. Ou lancez `python examples/run_flora_example.py` qui combine ces réglages.
 ## Format du fichier CSV
 
 L'option `--output` de `run.py` permet d'enregistrer les métriques de la

--- a/examples/run_basic.py
+++ b/examples/run_basic.py
@@ -9,6 +9,11 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 from simulateur_lora_sfrd.launcher import Simulator
 
 if __name__ == "__main__":
-    sim = Simulator(num_nodes=20, packet_interval=10, transmission_mode="Random")
+    sim = Simulator(
+        num_nodes=20,
+        packet_interval=10,
+        transmission_mode="Random",
+        adr_method="avg",
+    )
     sim.run(500)
     print(sim.get_metrics())

--- a/examples/run_flora_example.py
+++ b/examples/run_flora_example.py
@@ -12,7 +12,12 @@ from simulateur_lora_sfrd.launcher.adr_standard_1 import apply as adr1
 CONFIG = "flora-master/simulations/examples/n100-gw1.ini"
 
 if __name__ == "__main__":
-    sim = Simulator(flora_mode=True, config_file=CONFIG, seed=1)
+    sim = Simulator(
+        flora_mode=True,
+        config_file=CONFIG,
+        seed=1,
+        adr_method="avg",
+    )
     adr1(sim)
     sim.run(1000)
     print(sim.get_metrics())

--- a/simulateur_lora_sfrd/launcher/adr_standard_1.py
+++ b/simulateur_lora_sfrd/launcher/adr_standard_1.py
@@ -21,7 +21,10 @@ def apply(sim: Simulator, *, degrade_channel: bool = False) -> None:
     server.MARGIN_DB = Simulator.MARGIN_DB
     sim.adr_node = False
     sim.adr_server = True
+    # Utilise la moyenne de SNR sur 20 paquets comme dans FLoRa
+    sim.adr_method = "avg"
     sim.network_server.adr_enabled = True
+    sim.network_server.adr_method = "avg"
     for node in sim.nodes:
         node.sf = 12
         node.initial_sf = 12


### PR DESCRIPTION
## Summary
- use ADR based on average SNR in `adr_standard_1.apply`
- show `adr_method="avg"` in example scripts
- document ADR method in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68839f13f89c8331b0d8da22d1826308