### PR TITLE
Align traffic generation to FLoRa exponential

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ scénarios FLoRa. Voici la liste complète des options :
 - `packet_interval` : moyenne ou période fixe entre transmissions (s).
 - `interval_variation` : coefficient de jitter appliqué à l'intervalle
   exponentiel (0 par défaut pour coller au comportement FLoRa).
-- L'intervalle est tronqué à cinq fois `packet_interval` pour éviter des
-  écarts trop importants d'une exécution à l'autre.
+- Les instants de transmission suivent strictement une loi exponentielle de
+  moyenne `packet_interval` lorsque le mode `Random` est sélectionné.
 - `packets_to_send` : nombre de paquets émis **par nœud** avant arrêt (0 = infini).
 - `adr_node` / `adr_server` : active l'ADR côté nœud ou serveur.
 - `duty_cycle` : quota d'émission appliqué à chaque nœud (`None` pour désactiver).

--- a/simulateur_lora_sfrd/launcher/simulator.py
+++ b/simulateur_lora_sfrd/launcher/simulator.py
@@ -436,7 +436,7 @@ class Simulator:
                 high = 1.0 + self.interval_variation
                 factor = random.uniform(low, high)
                 interval *= factor
-            if interval <= 5 * self.packet_interval and interval >= min_interval:
+            if interval >= min_interval:
                 return interval
 
     def schedule_event(self, node: Node, time: float):

--- a/simulateur_lora_sfrd/run.py
+++ b/simulateur_lora_sfrd/run.py
@@ -56,10 +56,10 @@ def simulate(nodes, gateways, mode, interval, steps, channels=1,
     node_channels = {node: node % channels for node in range(nodes)}
     node_gateways = {node: node % max(1, gateways) for node in range(nodes)}
     def _sample_interval(mean: float, min_interval: float = 0.0) -> float:
-        """Retourne un délai tiré d'une loi exponentielle limitée."""
+        """Retourne un délai tiré d'une loi exponentielle."""
         while True:
             val = random.expovariate(1.0 / mean)
-            if val <= 5 * mean and val >= min_interval:
+            if val >= min_interval:
                 return val
 
     for node in range(nodes):


### PR DESCRIPTION
## Summary
- remove the upper bound when sampling emission intervals
- update quick simulator `_sample_interval`
- document the new exponential behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68839f6a37c883319212b3250ab66ac3