### PR TITLE
Enable FLoRa PHY automatically in flora_mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ avec l'option `flora_mode=True`. Ce mode applique automatiquement :
 - un exposant de perte de parcours fixé à `2.7` ;
 - un shadowing de `σ = 3.57` dB ;
 - un seuil de détection d'environ `-110` dBm.
+- l'utilisation automatique des formules FLoRa (`phy_model="flora"`).
 
 
 ## SF et puissance initiaux

--- a/simulateur_lora_sfrd/launcher/simulator.py
+++ b/simulateur_lora_sfrd/launcher/simulator.py
@@ -235,6 +235,9 @@ class Simulator:
             if detection_threshold_dBm != -float("inf"):
                 for ch in self.multichannel.channels:
                     ch.detection_threshold_dBm = detection_threshold_dBm
+            if flora_mode:
+                for ch in self.multichannel.channels:
+                    ch.phy_model = "flora"
             if flora_mode or phy_model == "flora":
                 for ch in self.multichannel.channels:
                     if getattr(ch, "environment", None) is None:
@@ -243,14 +246,17 @@ class Simulator:
         else:
             if channels is None:
                 env = "flora" if (flora_mode or phy_model == "flora") else None
+                ch_phy_model = "flora" if flora_mode else phy_model
                 ch_list = [Channel(detection_threshold_dBm=detection_threshold_dBm,
-                                  phy_model=phy_model, environment=env)]
+                                  phy_model=ch_phy_model, environment=env)]
             else:
                 ch_list = []
                 for ch in channels:
                     if isinstance(ch, Channel):
                         if detection_threshold_dBm != -float("inf"):
                             ch.detection_threshold_dBm = detection_threshold_dBm
+                        if flora_mode:
+                            ch.phy_model = "flora"
                         if (flora_mode or phy_model == "flora") and getattr(ch, "environment", None) is None:
                             ch.environment = "flora"
                             ch.path_loss_exp, ch.shadowing_std = Channel.ENV_PRESETS["flora"]
@@ -260,7 +266,7 @@ class Simulator:
                             Channel(
                                 frequency_hz=float(ch),
                                 detection_threshold_dBm=detection_threshold_dBm,
-                                phy_model=phy_model,
+                                phy_model="flora" if flora_mode else phy_model,
                                 environment="flora" if (flora_mode or phy_model == "flora") else None,
                             )
                         )


### PR DESCRIPTION
## Summary
- set all Channels to `phy_model="flora"` when `flora_mode` is enabled
- document automatic selection of FLoRa formulas in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883c9a185b48331b9482246d7387f75