### PR TITLE
Handle fast-forward when queue empty

### DIFF
--- a/simulateur_lora_sfrd/launcher/dashboard.py
+++ b/simulateur_lora_sfrd/launcher/dashboard.py
@@ -1021,6 +1021,12 @@ def fast_forward(event=None):
         if paused:
             export_message.object = "⚠️ Impossible d'accélérer pendant la pause."
             return
+        # If no events remain, finalise immediately without spawning a thread
+        if not sim.event_queue:
+            fast_forward_progress.visible = True
+            fast_forward_progress.value = 100
+            on_stop(None)
+            return
         auto_fast_forward = True
         if sim.packets_to_send == 0:
             export_message.object = (

--- a/tests/test_fast_forward_finished.py
+++ b/tests/test_fast_forward_finished.py
@@ -1,0 +1,22 @@
+import pytest
+
+from simulateur_lora_sfrd.launcher.simulator import Simulator
+import simulateur_lora_sfrd.launcher.dashboard as dashboard
+
+
+def test_fast_forward_on_finished_simulation():
+    sim = Simulator(num_nodes=1, num_gateways=1, packets_to_send=1, mobility=False)
+    sim.run()
+    assert not sim.event_queue
+
+    dashboard.sim = sim
+    dashboard.fast_forward_button.disabled = False
+    dashboard.fast_forward_progress.value = 0
+    dashboard.fast_forward_progress.visible = False
+
+    dashboard.fast_forward()
+
+    assert dashboard.fast_forward_button.disabled
+    assert dashboard.fast_forward_progress.value == 0
+    assert dashboard.fast_forward_progress.visible is False
+    assert dashboard.sim.running is False


### PR DESCRIPTION
## Summary
- finalize fast-forward immediately if no events are left
- test fast_forward() on a completed simulation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'panel')*

------
https://chatgpt.com/codex/tasks/task_e_6883d0b2c3a08331b3f24cf76479549f