### PR TITLE
Fix pause state reset and add pause finish test

### DIFF
--- a/simulateur_lora_sfrd/launcher/dashboard.py
+++ b/simulateur_lora_sfrd/launcher/dashboard.py
@@ -862,7 +862,10 @@ def on_stop(event):
     global current_run, total_runs, runs_events, auto_fast_forward
     # If called programmatically (e.g. after fast_forward), allow cleanup even
     # if the simulation has already stopped.
-    if sim is None or (event is not None and not sim.running):
+    if sim is None or (event is not None and not getattr(sim, "running", False)):
+        paused = False
+        pause_button.name = "⏸ Pause"
+        fast_forward_button.disabled = True
         return
 
     sim.running = False

--- a/tests/test_dashboard_pause.py
+++ b/tests/test_dashboard_pause.py
@@ -1,0 +1,31 @@
+import pytest
+import time
+
+
+dashboard = pytest.importorskip('simulateur_lora_sfrd.launcher.dashboard')
+
+
+def test_pause_then_finish_resets_buttons():
+    # use minimal packets to finish quickly
+    dashboard.packets_input.value = 1
+    dashboard.num_runs_input.value = 1
+
+    dashboard.setup_simulation()
+    assert dashboard.sim is not None
+    assert dashboard.sim.running
+
+    # Pause the simulation
+    dashboard.on_pause()
+    assert dashboard.paused
+    assert dashboard.pause_button.name.startswith('▶')
+
+    # Stop while paused
+    dashboard.on_stop(None)
+
+    assert not dashboard.paused
+    assert dashboard.pause_button.name == '⏸ Pause'
+    assert dashboard.fast_forward_button.disabled
+    assert not dashboard.start_button.disabled
+
+    # cleanup
+    dashboard._cleanup_callbacks()


### PR DESCRIPTION
## Summary
- ensure `on_stop` resets pause state when called after pausing
- add regression test covering stop after pause

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883d0cec2a88331a751d3f970daedea