### PR TITLE
Fix export button with updated FileSelector usage

### DIFF
--- a/simulateur_lora_sfrd/launcher/dashboard.py
+++ b/simulateur_lora_sfrd/launcher/dashboard.py
@@ -1052,7 +1052,7 @@ def exporter_csv(event=None, dest_dir=None):
 
     # Ask for destination directory first
     if dest_dir is None:
-        selector = pn.widgets.FileSelector(path=os.getcwd(), only_dirs=True)
+        selector = pn.widgets.FileSelector(directory=os.getcwd(), only_dirs=True)
         confirm = pn.widgets.Button(name="Exporter ici", button_type="primary")
 
         def _confirm(event):


### PR DESCRIPTION
## Summary
- fix exporter_csv to use `directory` parameter

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'panel')*

------
https://chatgpt.com/codex/tasks/task_e_6883d55d22648331ab74ad76c4df6c3b