### PR TITLE
Fix export button to save directly

### DIFF
--- a/simulateur_lora_sfrd/launcher/dashboard.py
+++ b/simulateur_lora_sfrd/launcher/dashboard.py
@@ -1036,31 +1036,13 @@ def on_stop(event):
 
 
 # --- Export CSV local : Méthode universelle ---
-def exporter_csv(event=None, dest_dir=None):
-    """Export simulation results as CSV files.
-
-    If ``dest_dir`` is not provided, a :class:`pn.widgets.FileSelector` widget is
-    displayed so the user can choose the destination folder. When a directory is
-    selected, the function is called again with ``dest_dir`` set.
-    """
-
+def exporter_csv(event=None):
+    """Export simulation results as CSV files in the current directory."""
+    dest_dir = os.getcwd()
     global runs_events, runs_metrics
 
     if not runs_events:
         export_message.object = "⚠️ Lance la simulation d'abord !"
-        return
-
-    # Ask for destination directory first
-    if dest_dir is None:
-        selector = pn.widgets.FileSelector(directory=os.getcwd(), only_dirs=True)
-        confirm = pn.widgets.Button(name="Exporter ici", button_type="primary")
-
-        def _confirm(event):
-            export_message.object = ""  # clear widget
-            exporter_csv(dest_dir=selector.value)
-
-        confirm.on_click(_confirm)
-        export_message.object = pn.Column(selector, confirm)
         return
 
     try:

--- a/tests/test_exporter_csv.py
+++ b/tests/test_exporter_csv.py
@@ -14,6 +14,7 @@ def test_export_to_tmp_dir(tmp_path, monkeypatch):
     dashboard.runs_metrics = [{"PDR": 100}]
     dashboard.export_message = pn.pane.Markdown()
     monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: None)
-    dashboard.exporter_csv(dest_dir=str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    dashboard.exporter_csv()
     files = list(tmp_path.glob("*.csv"))
     assert len(files) == 2

--- a/tests/test_fast_forward_finished.py
+++ b/tests/test_fast_forward_finished.py
@@ -1,6 +1,7 @@
 import pytest
 
 from simulateur_lora_sfrd.launcher.simulator import Simulator
+pn = pytest.importorskip("panel")
 import simulateur_lora_sfrd.launcher.dashboard as dashboard
 
 


### PR DESCRIPTION
## Summary
- revert export button to save results in current working directory
- update exporter_csv test
- skip fast-forward test when Panel isn't installed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883d6f1d9f4833180c77cda31ac739e