### PR TITLE
Remove interval capping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Significantly increased channel degradation in `adr_standard_1` for simulator validation.
-- Send interval distribution now matches FLoRa exactly with a 5× mean cap.
+- Send interval distribution now uses a strict exponential model without any cap to match FLoRa.
 
 ## [5.0] - 2025-07-24
 ### Added

--- a/simulateur_lora_sfrd/launcher/simulator.py
+++ b/simulateur_lora_sfrd/launcher/simulator.py
@@ -430,18 +430,13 @@ class Simulator:
         self.running = True
 
     def _sample_interval(self, min_interval: float = 0.0) -> float:
-        """Retourne un délai tiré de la loi exponentielle avec jitter.
+        """Retourne un délai tiré strictement d'une loi exponentielle.
 
         Les intervalles trop courts sont rééchantillonnés jusqu'à dépasser
         ``min_interval`` (durée du paquet précédent).
         """
         while True:
             interval = random.expovariate(1.0 / self.packet_interval)
-            if self.interval_variation > 0.0:
-                low = max(0.0, 1.0 - self.interval_variation)
-                high = 1.0 + self.interval_variation
-                factor = random.uniform(low, high)
-                interval *= factor
             if interval >= min_interval:
                 return interval
 


### PR DESCRIPTION
## Summary
- drop the jitter/cap from `_sample_interval`
- clarify changelog about the new exponential interval generation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883d9a9ce288331b7a1b6d48e67b67c