### PR TITLE
Add interval distribution test

### DIFF
--- a/tests/test_interval_distribution.py
+++ b/tests/test_interval_distribution.py
@@ -1,0 +1,14 @@
+import random
+from simulateur_lora_sfrd.launcher.simulator import Simulator
+
+
+def test_interval_distribution_mean():
+    """_sample_interval should follow an exponential distribution."""
+    mean_interval = 10.0
+    sim = Simulator(num_nodes=0, num_gateways=0, packet_interval=mean_interval, mobility=False)
+    count = 1_000_000
+    total = 0.0
+    for _ in range(count):
+        total += sim._sample_interval()
+    average = total / count
+    assert abs(average - mean_interval) / mean_interval < 0.01


### PR DESCRIPTION
## Summary
- add a test verifying that `_sample_interval` generates values with
  a mean close to `packet_interval` when sampling one million intervals

## Testing
- `PYTHONPATH=. pytest -q tests/test_interval_distribution.py -s`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883d9efe2ec8331b6a7551acc0238ce