### PR TITLE
Fix linter warnings

### DIFF
--- a/simulateur_lora_sfrd/launcher/planned_random_waypoint.py
+++ b/simulateur_lora_sfrd/launcher/planned_random_waypoint.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Iterable, List
+from typing import Iterable
 import random
 import math
 

--- a/simulateur_lora_sfrd/launcher/waypoint_planner.py
+++ b/simulateur_lora_sfrd/launcher/waypoint_planner.py
@@ -1,7 +1,7 @@
 # Path planner using A* over a terrain map with optional elevation and 3D obstacles.
 import math
 import random
-from typing import Iterable, List, Tuple
+from typing import List, Tuple
 
 
 class WaypointPlanner3D:

--- a/tests/test_dashboard_pause.py
+++ b/tests/test_dashboard_pause.py
@@ -1,5 +1,4 @@
 import pytest
-import time
 
 
 dashboard = pytest.importorskip('simulateur_lora_sfrd.launcher.dashboard')

--- a/tests/test_exporter_csv.py
+++ b/tests/test_exporter_csv.py
@@ -1,11 +1,10 @@
-import os
 import subprocess
 import pytest
 
 pn = pytest.importorskip("panel")
 pd = pytest.importorskip("pandas")
 
-from simulateur_lora_sfrd.launcher import dashboard
+from simulateur_lora_sfrd.launcher import dashboard  # noqa: E402
 
 
 def test_export_to_tmp_dir(tmp_path, monkeypatch):

--- a/tests/test_fast_forward_finished.py
+++ b/tests/test_fast_forward_finished.py
@@ -2,7 +2,7 @@ import pytest
 
 from simulateur_lora_sfrd.launcher.simulator import Simulator
 pn = pytest.importorskip("panel")
-import simulateur_lora_sfrd.launcher.dashboard as dashboard
+import simulateur_lora_sfrd.launcher.dashboard as dashboard  # noqa: E402
 
 
 def test_fast_forward_on_finished_simulation():

--- a/tests/test_interval_distribution.py
+++ b/tests/test_interval_distribution.py
@@ -1,4 +1,3 @@
-import random
 from simulateur_lora_sfrd.launcher.simulator import Simulator
 
 


### PR DESCRIPTION
## Summary
- resolve unused imports in mobility utilities
- clean up dashboard related tests
- silence import order warnings in tests

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883e0201ca8833199b50fa795a5a0c8