### PR TITLE
Align exponential RNG with OMNeT++

### DIFF
--- a/simulateur_lora_sfrd/run.py
+++ b/simulateur_lora_sfrd/run.py
@@ -114,17 +114,18 @@ def simulate(
                     n = nodes_on_ch[0]
                     rng = rng_manager.get_stream("traffic", n)
                     success = True
-                    if fine_fading_std > 0.0 and rng.gauss(0.0, fine_fading_std) < -3.0:
+                    if (
+                        fine_fading_std > 0.0
+                        and rng.normal(0.0, fine_fading_std) < -3.0
+                    ):
                         success = False
-                    if noise_std > 0.0 and rng.gauss(0.0, noise_std) > 3.0:
+                    if noise_std > 0.0 and rng.normal(0.0, noise_std) > 3.0:
                         success = False
                     if success:
                         delivered += 1
                         delays.append(0)
                         if debug_rx:
-                            logging.debug(
-                                f"t={t:.3f} Node {n} GW {gw} CH {ch} reçu"
-                            )
+                            logging.debug(f"t={t:.3f} Node {n} GW {gw} CH {ch} reçu")
                     else:
                         collisions += 1
                         if debug_rx:
@@ -138,9 +139,12 @@ def simulate(
                     rng = rng_manager.get_stream("traffic", nodes_on_ch[0])
                     winner = rng.choice(nodes_on_ch)
                     success = True
-                    if fine_fading_std > 0.0 and rng.gauss(0.0, fine_fading_std) < -3.0:
+                    if (
+                        fine_fading_std > 0.0
+                        and rng.normal(0.0, fine_fading_std) < -3.0
+                    ):
                         success = False
-                    if noise_std > 0.0 and rng.gauss(0.0, noise_std) > 3.0:
+                    if noise_std > 0.0 and rng.normal(0.0, noise_std) > 3.0:
                         success = False
                     if success:
                         collisions += nb_tx - 1
@@ -171,11 +175,7 @@ def simulate(
                         )
 
     # Calcul des métriques finales
-    pdr = (
-        (delivered / total_transmissions) * 100
-        if total_transmissions > 0
-        else 0
-    )
+    pdr = (delivered / total_transmissions) * 100 if total_transmissions > 0 else 0
     avg_delay = (sum(delays) / len(delays)) if delays else 0
     throughput_bps = delivered * PAYLOAD_SIZE * 8 / steps if steps > 0 else 0.0
 
@@ -197,12 +197,8 @@ def main(argv=None):
         default="config.ini",
         help="Fichier INI de configuration des paramètres",
     )
-    parser.add_argument(
-        "--nodes", type=int, default=10, help="Nombre de nœuds"
-    )
-    parser.add_argument(
-        "--gateways", type=int, default=1, help="Nombre de gateways"
-    )
+    parser.add_argument("--nodes", type=int, default=10, help="Nombre de nœuds")
+    parser.add_argument("--gateways", type=int, default=1, help="Nombre de gateways")
     parser.add_argument(
         "--channels", type=int, default=1, help="Nombre de canaux radio"
     )
@@ -304,9 +300,7 @@ def main(argv=None):
         ns.send_downlink(node, b"ack")
         rx1, _ = node.schedule_receive_windows(0)
         gw.pop_downlink(node.id)  # illustration
-        logging.info(
-            f"Exemple LoRaWAN : trame uplink FCnt={frame.fcnt}, RX1={rx1}s"
-        )
+        logging.info(f"Exemple LoRaWAN : trame uplink FCnt={frame.fcnt}, RX1={rx1}s")
         sys.exit()
 
     results = []
@@ -327,9 +321,7 @@ def main(argv=None):
             phy_model=args.phy_model,
             rng_manager=rng_manager,
         )
-        results.append(
-            (delivered, collisions, pdr, energy, avg_delay, throughput)
-        )
+        results.append((delivered, collisions, pdr, energy, avg_delay, throughput))
         logging.info(
             f"Run {i + 1}/{args.runs} : PDR={pdr:.2f}% , Paquets livrés={delivered}, Collisions={collisions}, "
             f"Énergie consommée={energy:.1f} unités, Délai moyen={avg_delay:.2f} unités de temps, "

--- a/tests/test_interval_distribution.py
+++ b/tests/test_interval_distribution.py
@@ -1,4 +1,4 @@
-from random import Random
+import numpy as np
 from traffic.exponential import sample_interval
 
 
@@ -6,7 +6,7 @@ def test_interval_distribution_mean():
     """_sample_interval should follow an exponential distribution."""
     mean_interval = 10.0
     count = 1_000_000
-    rng = Random(0)
+    rng = np.random.Generator(np.random.MT19937(0))
     total = 0.0
     for _ in range(count):
         total += sample_interval(mean_interval, rng)

--- a/traffic/exponential.py
+++ b/traffic/exponential.py
@@ -1,5 +1,23 @@
-from random import Random
+"""Exponential distribution aligned with OMNeT++."""
 
-def sample_interval(mean: float, rng: Random) -> float:
-    """Return a delay drawn from an exponential distribution."""
-    return rng.expovariate(1.0 / mean)
+from __future__ import annotations
+
+import math
+import numpy as np
+
+
+def sample_interval(mean: float, rng: np.random.Generator) -> float:
+    """Return a delay drawn from an exponential distribution.
+
+    The value is generated using inverse transform sampling with a
+    ``numpy.random.Generator`` based on ``MT19937`` to match the algorithm
+    used by OMNeT++.
+    """
+    if not isinstance(rng, np.random.Generator) or not isinstance(
+        rng.bit_generator, np.random.MT19937
+    ):
+        raise TypeError("rng must be numpy.random.Generator using MT19937")
+    u = rng.random()
+    while u <= 0.0:
+        u = rng.random()
+    return -mean * math.log(u)

--- a/traffic/rng_manager.py
+++ b/traffic/rng_manager.py
@@ -1,21 +1,20 @@
 from __future__ import annotations
 
-from random import Random
+import numpy as np
 from typing import Dict, Tuple
 
 
 class RngManager:
-    """Manage deterministic RNG streams."""
+    """Manage deterministic RNG streams based on MT19937."""
 
     def __init__(self, master_seed: int) -> None:
         self.master_seed = master_seed
-        self._streams: Dict[Tuple[str, int], Random] = {}
+        self._streams: Dict[Tuple[str, int], np.random.Generator] = {}
 
-    def get_stream(self, stream_name: str, node_id: int = 0) -> Random:
-        """Return a Random instance for the given stream and node."""
+    def get_stream(self, stream_name: str, node_id: int = 0) -> np.random.Generator:
+        """Return a Generator instance for the given stream and node."""
         key = (stream_name, node_id)
         if key not in self._streams:
             seed = self.master_seed ^ hash(stream_name) ^ node_id
-            self._streams[key] = Random(seed)
+            self._streams[key] = np.random.Generator(np.random.MT19937(seed))
         return self._streams[key]
-


### PR DESCRIPTION
## Summary
- implement `sample_interval` using `Generator(MT19937)` and inverse transform sampling
- provide `RngManager` class returning MT19937 generators
- update simulator code to rely on `normal` for Gaussian draws
- adjust interval distribution test for the new generator

## Testing
- `ruff check traffic/exponential.py traffic/rng_manager.py simulateur_lora_sfrd/run.py tests/test_interval_distribution.py`
- `black traffic/exponential.py traffic/rng_manager.py simulateur_lora_sfrd/run.py tests/test_interval_distribution.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6883eef8e384833192b1ac28a46b30d8