### PR TITLE
Handle Poisson arrivals independently of duty cycle

### DIFF
--- a/tests/test_raw_interval.py
+++ b/tests/test_raw_interval.py
@@ -1,0 +1,18 @@
+import numpy as np
+from simulateur_lora_sfrd.launcher.simulator import Simulator
+
+
+def test_avg_arrival_interval():
+    sim = Simulator(
+        num_nodes=1,
+        num_gateways=1,
+        transmission_mode="Random",
+        packet_interval=5.0,
+        packets_to_send=50,
+        duty_cycle=0.01,
+        mobility=False,
+        seed=0,
+    )
+    sim.run()
+    metrics = sim.get_metrics()
+    assert abs(metrics["avg_arrival_interval_s"] - 5.0) / 5.0 < 0.1


### PR DESCRIPTION
## Summary
- track Poisson arrival timestamps per node
- generate arrival schedule independent of duty-cycle delay
- expose `avg_arrival_interval_s` metric
- test mean arrival interval

## Testing
- `black -q simulateur_lora_sfrd/launcher/node.py simulateur_lora_sfrd/launcher/simulator.py tests/test_raw_interval.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6883f05e9878833191d45c6484c2b255