### PR TITLE
Enforce second-based mean_interval

### DIFF
--- a/simulateur_lora_sfrd/launcher/node.py
+++ b/simulateur_lora_sfrd/launcher/node.py
@@ -391,6 +391,9 @@ class Node:
         limit: int | None = None,
     ) -> None:
         """Generate Poisson arrival times up to ``up_to`` seconds."""
+        assert isinstance(mean_interval, float) and mean_interval > 0, (
+            "mean_interval must be positive float"
+        )
         last = self.arrival_queue[-1] if self.arrival_queue else self._last_arrival_time
         while (not self.arrival_queue or last <= up_to) and (
             limit is None or self.arrival_interval_count < limit

--- a/simulateur_lora_sfrd/run.py
+++ b/simulateur_lora_sfrd/run.py
@@ -49,6 +49,9 @@ def simulate(
         raise ValueError("gateways must be >= 1")
     if channels < 1:
         raise ValueError("channels must be >= 1")
+    assert isinstance(interval, float) and interval > 0, (
+        "mean_interval must be positive float"
+    )
     if interval <= 0:
         raise ValueError("interval must be > 0")
     if steps <= 0:

--- a/tests/test_interval_asserts.py
+++ b/tests/test_interval_asserts.py
@@ -1,0 +1,22 @@
+import numpy as np
+import pytest
+
+from traffic.exponential import sample_interval
+from simulateur_lora_sfrd.launcher.node import Node
+
+
+def test_sample_interval_asserts():
+    rng = np.random.Generator(np.random.MT19937(0))
+    with pytest.raises(AssertionError):
+        sample_interval(-1.0, rng)
+    with pytest.raises(AssertionError):
+        sample_interval(10, rng)  # not float
+
+
+def test_node_poisson_assert():
+    rng = np.random.Generator(np.random.MT19937(0))
+    node = Node(0, 0, 0, 7, 20)
+    with pytest.raises(AssertionError):
+        node.ensure_poisson_arrivals(10.0, rng, -5.0)
+    with pytest.raises(AssertionError):
+        node.ensure_poisson_arrivals(10.0, rng, 5)

--- a/tests/test_run_simulate.py
+++ b/tests/test_run_simulate.py
@@ -9,7 +9,7 @@ def test_simulate_single_node_periodic():
         1,
         1,
         "Periodic",
-        1,
+        1.0,
         10,
         rng_manager=rng_manager,
     )
@@ -39,11 +39,11 @@ def test_simulate_periodic_float_interval():
 @pytest.mark.parametrize(
     "nodes, gateways, mode, interval, steps",
     [
-        (0, 1, "random", 10, 10),
-        (1, 0, "random", 10, 10),
-        (1, 1, "random", 0, 10),
-        (1, 1, "random", 10, 0),
-        (1, 1, "bad", 10, 10),
+        (0, 1, "random", 10.0, 10),
+        (1, 0, "random", 10.0, 10),
+        (1, 1, "random", 0.0, 10),
+        (1, 1, "random", 10.0, 0),
+        (1, 1, "bad", 10.0, 10),
     ],
 )
 def test_simulate_invalid_parameters(nodes, gateways, mode, interval, steps):

--- a/traffic/exponential.py
+++ b/traffic/exponential.py
@@ -9,6 +9,9 @@ import numpy as np
 def sample_interval(mean: float, rng: np.random.Generator) -> float:
     """Return a delay drawn from an exponential distribution.
 
+    ``mean`` is expressed in seconds and must be a positive float. Any
+    other type or non-positive value triggers an :class:`AssertionError`.
+
     The value is generated using inverse transform sampling with a
     ``numpy.random.Generator`` based on ``MT19937`` to match the algorithm
     used by OMNeT++.
@@ -17,6 +20,7 @@ def sample_interval(mean: float, rng: np.random.Generator) -> float:
         rng.bit_generator, np.random.MT19937
     ):
         raise TypeError("rng must be numpy.random.Generator using MT19937")
+    assert isinstance(mean, float) and mean > 0, "mean_interval must be positive float"
     u = rng.random()
     while u <= 0.0:
         u = rng.random()


### PR DESCRIPTION
## Summary
- enforce `mean_interval` in seconds
- add strict asserts about positive floats
- adapt simulator runtime checks
- adjust existing tests and add new tests for asserts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6883f3b53fac833181dca52b31372d52