### PR TITLE
Fix Poisson arrival scheduling

### DIFF
--- a/simulateur_lora_sfrd/launcher/simulator.py
+++ b/simulateur_lora_sfrd/launcher/simulator.py
@@ -465,7 +465,7 @@ class Simulator:
         for node in self.nodes:
             if self.transmission_mode.lower() == "random":
                 node.ensure_poisson_arrivals(
-                    0.0,
+                    node._last_arrival_time,
                     self.interval_rng,
                     self.packet_interval,
                     self.packets_to_send if self.packets_to_send else None,
@@ -821,7 +821,7 @@ class Simulator:
                 ):
                     if self.transmission_mode.lower() == "random":
                         node.ensure_poisson_arrivals(
-                            self.current_time,
+                            node._last_arrival_time,
                             self.interval_rng,
                             self.packet_interval,
                             self.packets_to_send if self.packets_to_send else None,


### PR DESCRIPTION
## Summary
- avoid drawing new intervals from delayed send times
- schedule new Poisson arrivals based only on the previously planned event

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883f966183083318a01f8f8d2467a4a