### PR TITLE
Add deterministic interval generation test

### DIFF
--- a/tests/test_seed_stability.py
+++ b/tests/test_seed_stability.py
@@ -1,0 +1,24 @@
+import hashlib
+import struct
+
+from traffic.rng_manager import RngManager
+from simulateur_lora_sfrd.launcher.node import Node
+
+
+def _intervals_hash(seed: int, mean_interval: float = 1.0, count: int = 10000) -> str:
+    rng = RngManager(seed).get_stream("traffic", 0)
+    node = Node(0, 0, 0, 7, 14)
+    node.ensure_poisson_arrivals(1e9, rng, mean_interval, limit=count)
+    h = hashlib.sha256()
+    last = 0.0
+    for t in node.arrival_queue:
+        h.update(struct.pack("<d", t - last))
+        last = t
+    return h.hexdigest()
+
+
+def test_seed_reproducibility():
+    seed = 42
+    hashes = [_intervals_hash(seed) for _ in range(10)]
+    assert len(set(hashes)) == 1
+


### PR DESCRIPTION
## Summary
- ensure Node produces deterministic intervals when run repeatedly with the same seed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883fb4149348331becf75fb36b9a0bb