### PR TITLE
Add multi-seed mean check for sample_interval

### DIFF
--- a/tests/test_interval_distribution.py
+++ b/tests/test_interval_distribution.py
@@ -1,12 +1,21 @@
 import numpy as np
+import pytest
+
 from traffic.exponential import sample_interval
 
 
-def test_interval_distribution_mean():
-    """_sample_interval should follow an exponential distribution."""
+@pytest.mark.parametrize("seed", range(10))
+def test_interval_distribution_mean(seed: int) -> None:
+    """``sample_interval`` should preserve the configured mean.
+
+    The test draws ``count`` samples from several RNG streams and checks that
+    the empirical mean stays within 1% of ``mean_interval``. Using multiple
+    seeds helps detect potential systematic bias in the implementation.
+    """
+
     mean_interval = 10.0
     count = 1_000_000
-    rng = np.random.Generator(np.random.MT19937(0))
+    rng = np.random.Generator(np.random.MT19937(seed))
     total = 0.0
     for _ in range(count):
         total += sample_interval(mean_interval, rng)


### PR DESCRIPTION
## Summary
- extend interval distribution test to run on 10 seeds
- ensure observed mean stays within 1% of the parameter for each seed

## Testing
- `pytest -k interval_distribution -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883fb5bd1c08331ac2e6e292bfccb78