### PR TITLE
Add interval dump option

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,7 @@ l'utilisation du simulateur :
 
 ```bash
 python examples/run_basic.py          # simulation rapide avec 20 nœuds
+python examples/run_basic.py --dump-intervals  # exporte les intervalles
 python examples/run_flora_example.py  # reproduction d'un scénario FLoRa
 ```
 

--- a/examples/run_basic.py
+++ b/examples/run_basic.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import argparse
 
 # Ajoute le répertoire parent pour pouvoir importer le package
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -9,11 +10,22 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 from simulateur_lora_sfrd.launcher import Simulator
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Exemple basique de simulation LoRa")
+    parser.add_argument("--nodes", type=int, default=20, help="Nombre de nœuds")
+    parser.add_argument("--steps", type=int, default=500, help="Durée de la simulation")
+    parser.add_argument(
+        "--dump-intervals",
+        action="store_true",
+        help="Exporte les intervalles dans des fichiers Parquet",
+    )
+    args = parser.parse_args()
+
     sim = Simulator(
-        num_nodes=20,
+        num_nodes=args.nodes,
         packet_interval=10,
         transmission_mode="Random",
         adr_method="avg",
+        dump_intervals=args.dump_intervals,
     )
-    sim.run(500)
+    sim.run(args.steps)
     print(sim.get_metrics())

--- a/simulateur_lora_sfrd/launcher/node.py
+++ b/simulateur_lora_sfrd/launcher/node.py
@@ -227,6 +227,9 @@ class Node:
         self.arrival_interval_count: int = 0
         self._last_arrival_time: float = 0.0
 
+        # Historique complet des intervalles programmés/réels
+        self.interval_log: list[dict] = []
+
         # Energy accounting state
         self.last_state_time = 0.0
         self.state = "sleep"

--- a/simulateur_lora_sfrd/launcher/simulator.py
+++ b/simulateur_lora_sfrd/launcher/simulator.py
@@ -100,6 +100,7 @@ class Simulator:
         ping_slot_interval: float = 1.0,
         ping_slot_offset: float = 2.0,
         debug_rx: bool = False,
+        dump_intervals: bool = False,
     ):
         """
         Initialise la simulation LoRa avec les entités et paramètres donnés.
@@ -170,6 +171,7 @@ class Simulator:
         :param ping_slot_offset: Décalage initial entre le beacon et le premier
             ping slot (s).
         :param debug_rx: Active la journalisation détaillée des paquets reçus ou rejetés.
+        :param dump_intervals: Exporte la série complète des intervalles dans un fichier Parquet.
         """
         # Paramètres de simulation
         self.num_nodes = num_nodes
@@ -245,6 +247,7 @@ class Simulator:
         self.clock_accuracy = clock_accuracy
         self.beacon_loss_prob = beacon_loss_prob
         self.debug_rx = debug_rx
+        self.dump_intervals = dump_intervals
 
         # Gestion du duty cycle (activé par défaut à 1 %)
         self.duty_cycle_manager = DutyCycleManager(duty_cycle) if duty_cycle else None
@@ -477,7 +480,11 @@ class Simulator:
                 node.arrival_interval_sum += t0
                 node.arrival_interval_count += 1
                 node._last_arrival_time = t0
-            self.schedule_event(node, t0)
+            self.schedule_event(
+                node,
+                t0,
+                reason="poisson" if self.transmission_mode.lower() == "random" else "periodic",
+            )
             # Planifier le premier changement de position si la mobilité est activée
             if self.mobility_enabled:
                 self.schedule_mobility(node, self.mobility_model.step)
@@ -502,19 +509,31 @@ class Simulator:
         # Indicateur d'exécution de la simulation
         self.running = True
 
-    def schedule_event(self, node: Node, time: float):
-        """Planifie un événement de transmission pour un nœud à l'instant donné."""
+    def schedule_event(self, node: Node, time: float, *, reason: str = "poisson"):
+        """Planifie un événement de transmission pour un nœud."""
         if not node.alive:
             return
+        requested_time = time
         event_id = self.event_id_counter
         self.event_id_counter += 1
         if self.duty_cycle_manager:
-            time = self.duty_cycle_manager.enforce(node.id, time)
+            enforced = self.duty_cycle_manager.enforce(node.id, time)
+            if enforced > time:
+                time = enforced
+                reason = "duty_cycle"
         node.channel = self.multichannel.select_mask(getattr(node, "chmask", 0xFFFF))
         heapq.heappush(
             self.event_queue,
             Event(time, EventType.TX_START, event_id, node.id),
         )
+        if self.dump_intervals:
+            node.interval_log.append(
+                {
+                    "poisson_time": requested_time,
+                    "tx_time": time,
+                    "reason": reason,
+                }
+            )
         logger.debug(
             f"Scheduled transmission {event_id} for node {node.id} at t={time:.2f}s"
         )
@@ -813,7 +832,7 @@ class Simulator:
             # Planifier retransmissions restantes ou prochaine émission
             if node._nb_trans_left > 0:
                 self.retransmissions += 1
-                self.schedule_event(node, self.current_time + 1.0)
+                self.schedule_event(node, self.current_time + 1.0, reason="retransmission")
             else:
                 if (
                     self.packets_to_send == 0
@@ -832,7 +851,13 @@ class Simulator:
                         node.arrival_interval_sum += self.packet_interval
                         node.arrival_interval_count += 1
                         node._last_arrival_time = next_time
-                    self.schedule_event(node, next_time)
+                    self.schedule_event(
+                        node,
+                        next_time,
+                        reason="poisson"
+                        if self.transmission_mode.lower() == "random"
+                        else "periodic",
+                    )
                 else:
                     logger.debug(
                         "Packet limit reached for node %s – no more events for this node.",
@@ -1061,6 +1086,8 @@ class Simulator:
             step_count += 1
             if max_steps and step_count >= max_steps:
                 break
+        if self.dump_intervals:
+            self.dump_interval_logs()
 
     def stop(self):
         """Arrête la simulation en cours."""
@@ -1226,3 +1253,17 @@ class Simulator:
             if col not in df.columns:
                 df[col] = None
         return df[columns_order]
+
+    def dump_interval_logs(self, dest: str | Path = ".") -> None:
+        """Écrit les intervalles théoriques et réels de chaque nœud en Parquet."""
+        if not self.dump_intervals:
+            return
+        if pd is None:
+            raise RuntimeError("pandas is required for this feature")
+        dest_path = Path(dest)
+        dest_path.mkdir(parents=True, exist_ok=True)
+        for node in self.nodes:
+            if not node.interval_log:
+                continue
+            df = pd.DataFrame(node.interval_log)
+            df.to_parquet(dest_path / f"intervals_node_{node.id}.parquet", index=False)


### PR DESCRIPTION
## Summary
- track per-node interval history
- add `--dump-intervals` option to example runner
- export interval logs to Parquet when enabled
- document new option in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883fb7e09588331969bb4e28c26f3ad