### PR TITLE
Improve scheduler time precision using int nanoseconds

### DIFF
--- a/simulateur_lora_sfrd/launcher/server.py
+++ b/simulateur_lora_sfrd/launcher/server.py
@@ -180,13 +180,13 @@ class NetworkServer:
             elif node.class_type.upper() == "C":
                 self.scheduler.schedule_class_c(node, at_time, frame, gw, priority=priority)
                 if self.simulator is not None:
-                    from .simulator import Event, EventType
+                    from .simulator import Event, EventType, _to_ns
 
                     eid = self.simulator.event_id_counter
                     self.simulator.event_id_counter += 1
                     heapq.heappush(
                         self.simulator.event_queue,
-                        Event(at_time, EventType.RX_WINDOW, eid, node.id),
+                        Event(_to_ns(at_time), EventType.RX_WINDOW, eid, node.id),
                     )
             else:
                 self.scheduler.schedule(node.id, at_time, frame, gw, priority=priority)
@@ -219,7 +219,7 @@ class NetworkServer:
             self.receive(event_id, node_id, gateway_id, rssi, frame)
             return
 
-        from .simulator import Event, EventType
+        from .simulator import Event, EventType, _to_ns
 
         arrival_time = (
             (at_time if at_time is not None else self.simulator.current_time)
@@ -235,7 +235,7 @@ class NetworkServer:
         self.pending_process[eid] = (event_id, node_id, gateway_id, rssi, frame)
         heapq.heappush(
             self.simulator.event_queue,
-            Event(arrival_time, EventType.SERVER_RX, eid, node_id),
+            Event(_to_ns(arrival_time), EventType.SERVER_RX, eid, node_id),
         )
 
     def _handle_network_arrival(self, eid: int) -> None:
@@ -243,7 +243,7 @@ class NetworkServer:
         info = self.pending_process.pop(eid, None)
         if not info:
             return
-        from .simulator import Event, EventType
+        from .simulator import Event, EventType, _to_ns
 
         process_time = self.simulator.current_time + self.process_delay
         new_id = self.simulator.event_id_counter
@@ -252,7 +252,7 @@ class NetworkServer:
         node_id = info[1]
         heapq.heappush(
             self.simulator.event_queue,
-            Event(process_time, EventType.SERVER_PROCESS, new_id, node_id),
+            Event(_to_ns(process_time), EventType.SERVER_PROCESS, new_id, node_id),
         )
 
     def _process_scheduled(self, eid: int) -> None:


### PR DESCRIPTION
## Summary
- store event timestamps as integer nanoseconds
- convert between float seconds and nanoseconds when scheduling and executing events

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883ffd290008331862e0782e66a6e66