### PR TITLE
Parse mean interval from FLoRa ini

### DIFF
--- a/simulateur_lora_sfrd/launcher/config_loader.py
+++ b/simulateur_lora_sfrd/launcher/config_loader.py
@@ -1,5 +1,6 @@
 import configparser
 import json
+import re
 from pathlib import Path
 
 def load_config(path: str | Path) -> tuple[list[dict], list[dict]]:
@@ -90,3 +91,18 @@ def write_flora_ini(
     }
     with open(path, "w") as f:
         cp.write(f)
+
+
+def parse_flora_interval(path: str | Path) -> float | None:
+    """Return the mean packet interval defined in a FLoRa INI file.
+
+    The function searches for a parameter ``timeToNextPacket`` expressed as
+    ``exponential(<value>s)`` and returns ``<value>`` as a float. ``None`` is
+    returned when the parameter cannot be found.
+    """
+
+    text = Path(path).read_text()
+    match = re.search(r"timeToNextPacket\s*=\s*exponential\((\d+(?:\.\d+)?)s\)", text)
+    if match:
+        return float(match.group(1))
+    return None

--- a/simulateur_lora_sfrd/launcher/simulator.py
+++ b/simulateur_lora_sfrd/launcher/simulator.py
@@ -351,13 +351,16 @@ class Simulator:
         cfg_nodes = None
         cfg_gateways = None
         if config_file:
-            from .config_loader import load_config
+            from .config_loader import load_config, parse_flora_interval
 
             cfg_nodes, cfg_gateways = load_config(config_file)
             if cfg_gateways:
                 self.num_gateways = len(cfg_gateways)
             if cfg_nodes:
                 self.num_nodes = len(cfg_nodes)
+            mean_interval = parse_flora_interval(config_file)
+            if mean_interval is not None:
+                self.packet_interval = mean_interval
 
         for idx in range(self.num_gateways):
             gw_id = next_gateway_id()

--- a/tests/test_flora_interval.py
+++ b/tests/test_flora_interval.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+from simulateur_lora_sfrd.launcher.simulator import Simulator
+from simulateur_lora_sfrd.launcher.config_loader import parse_flora_interval
+
+
+def test_flora_ini_interval_parsing():
+    ini_path = Path('flora-master/simulations/examples/n100-gw1.ini')
+    mean_f = parse_flora_interval(ini_path)
+    assert mean_f is not None
+    sim = Simulator(flora_mode=True, config_file=str(ini_path))
+    assert sim.packet_interval == mean_f


### PR DESCRIPTION
## Summary
- parse `timeToNextPacket` from FLoRa INI files
- use that interval when instantiating a Simulator with a FLoRa config
- test that the interval is imported correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68840005a5b083318afde10476aad826