### PR TITLE
Add pure Poisson validation preset

### DIFF
--- a/simulateur_lora_sfrd/launcher/simulator.py
+++ b/simulateur_lora_sfrd/launcher/simulator.py
@@ -103,6 +103,7 @@ class Simulator:
         ping_slot_offset: float = 2.0,
         debug_rx: bool = False,
         dump_intervals: bool = False,
+        pure_poisson_mode: bool = False,
     ):
         """
         Initialise la simulation LoRa avec les entités et paramètres donnés.
@@ -203,8 +204,13 @@ class Simulator:
                 detection_threshold_dBm = -110.0
             if min_interference_time == 0.0:
                 min_interference_time = 5.0
+        if pure_poisson_mode:
+            duty_cycle = None
+            detection_threshold_dBm = -float("inf")
+            min_interference_time = float("inf")
         self.detection_threshold_dBm = detection_threshold_dBm
         self.min_interference_time = min_interference_time
+        self.pure_poisson_mode = pure_poisson_mode
         self.flora_mode = flora_mode
         self.flora_timing = flora_timing
         self.config_file = config_file
@@ -525,7 +531,7 @@ class Simulator:
         requested_time = time
         event_id = self.event_id_counter
         self.event_id_counter += 1
-        if self.duty_cycle_manager:
+        if self.duty_cycle_manager and not self.pure_poisson_mode:
             enforced = self.duty_cycle_manager.enforce(node.id, time)
             if enforced > time:
                 time = enforced
@@ -592,7 +598,7 @@ class Simulator:
             duration = node.channel.airtime(sf, payload_size=self.payload_size_bytes)
             node.last_airtime = duration
             end_time = time + duration
-            if self.duty_cycle_manager:
+            if self.duty_cycle_manager and not self.pure_poisson_mode:
                 self.duty_cycle_manager.update_after_tx(node_id, time, duration)
             # Mettre à jour les compteurs de paquets émis
             self.packets_sent += 1
@@ -636,14 +642,15 @@ class Simulator:
                 )
                 rssi += getattr(gw, "rx_gain_dB", 0.0)
                 snr += getattr(gw, "rx_gain_dB", 0.0)
-                if rssi < node.channel.detection_threshold_dBm:
-                    continue  # trop faible pour être détecté
-                snr_threshold = (
-                    node.channel.sensitivity_dBm.get(sf, -float("inf"))
-                    - node.channel.noise_floor_dBm()
-                )
-                if snr < snr_threshold:
-                    continue  # signal trop faible pour être reçu
+                if not self.pure_poisson_mode:
+                    if rssi < node.channel.detection_threshold_dBm:
+                        continue  # trop faible pour être détecté
+                    snr_threshold = (
+                        node.channel.sensitivity_dBm.get(sf, -float("inf"))
+                        - node.channel.noise_floor_dBm()
+                    )
+                    if snr < snr_threshold:
+                        continue  # signal trop faible pour être reçu
                 heard_by_any = True
                 if best_rssi is None or rssi > best_rssi:
                     best_rssi = rssi
@@ -926,17 +933,20 @@ class Simulator:
                     node.sf,
                     **kwargs,
                 )
-                if rssi < node.channel.detection_threshold_dBm:
-                    node.downlink_pending = max(0, node.downlink_pending - 1)
-                    continue
-                snr_threshold = (
-                    node.channel.sensitivity_dBm.get(node.sf, -float("inf"))
-                    - node.channel.noise_floor_dBm()
-                )
-                if snr >= snr_threshold:
-                    node.handle_downlink(frame)
+                if not self.pure_poisson_mode:
+                    if rssi < node.channel.detection_threshold_dBm:
+                        node.downlink_pending = max(0, node.downlink_pending - 1)
+                        continue
+                    snr_threshold = (
+                        node.channel.sensitivity_dBm.get(node.sf, -float("inf"))
+                        - node.channel.noise_floor_dBm()
+                    )
+                    if snr >= snr_threshold:
+                        node.handle_downlink(frame)
+                    else:
+                        node.downlink_pending = max(0, node.downlink_pending - 1)
                 else:
-                    node.downlink_pending = max(0, node.downlink_pending - 1)
+                    node.handle_downlink(frame)
                 break
             # Replanifier selon la classe du nœud
             if node.class_type.upper() == "C":
@@ -1024,17 +1034,20 @@ class Simulator:
                     sf,
                     **kwargs,
                 )
-                if rssi < node.channel.detection_threshold_dBm:
-                    node.downlink_pending = max(0, node.downlink_pending - 1)
-                    continue
-                snr_threshold = (
-                    node.channel.sensitivity_dBm.get(sf, -float("inf"))
-                    - node.channel.noise_floor_dBm()
-                )
-                if snr >= snr_threshold:
-                    node.handle_downlink(frame)
+                if not self.pure_poisson_mode:
+                    if rssi < node.channel.detection_threshold_dBm:
+                        node.downlink_pending = max(0, node.downlink_pending - 1)
+                        continue
+                    snr_threshold = (
+                        node.channel.sensitivity_dBm.get(sf, -float("inf"))
+                        - node.channel.noise_floor_dBm()
+                    )
+                    if snr >= snr_threshold:
+                        node.handle_downlink(frame)
+                    else:
+                        node.downlink_pending = max(0, node.downlink_pending - 1)
                 else:
-                    node.downlink_pending = max(0, node.downlink_pending - 1)
+                    node.handle_downlink(frame)
                 break
             return True
 

--- a/tests/test_raw_interval.py
+++ b/tests/test_raw_interval.py
@@ -10,6 +10,7 @@ def test_avg_arrival_interval():
         packet_interval=5.0,
         packets_to_send=50,
         duty_cycle=0.01,
+        pure_poisson_mode=True,
         mobility=False,
         seed=0,
     )

--- a/tests/test_warmup.py
+++ b/tests/test_warmup.py
@@ -13,6 +13,7 @@ def test_warmup_intervals():
         duty_cycle=0.01,
         mobility=False,
         seed=1,
+        pure_poisson_mode=True,
     )
     sim.run()
     node = sim.nodes[0]


### PR DESCRIPTION
## Summary
- add a `pure_poisson_mode` option to `Simulator`
- skip duty cycle and channel degradation when preset is enabled
- use pure Poisson preset in interval tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68840052569c8331ba180027f773be0f