### PR TITLE
Add global RNG safety hooks

### DIFF
--- a/traffic/__init__.py
+++ b/traffic/__init__.py
@@ -1,3 +1,13 @@
-from .rng_manager import RngManager
+from .rng_manager import (
+    RngManager,
+    activate_global_hooks,
+    deactivate_global_hooks,
+    UncontrolledRandomError,
+)
 
-__all__ = ["RngManager"]
+__all__ = [
+    "RngManager",
+    "activate_global_hooks",
+    "deactivate_global_hooks",
+    "UncontrolledRandomError",
+]

--- a/traffic/rng_manager.py
+++ b/traffic/rng_manager.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
 import hashlib
+import random
+import secrets
+import weakref
 import numpy as np
 from typing import Dict, Tuple
+
+
+class UncontrolledRandomError(RuntimeError):
+    """Raised when an unmanaged RNG source is accessed."""
 
 
 class RngManager:
@@ -21,5 +28,105 @@ class RngManager:
             digest = hashlib.sha256(stream_name.encode()).digest()
             stream_hash = int.from_bytes(digest[:8], "little")
             seed = (self.master_seed ^ stream_hash ^ node_id) & 0xFFFFFFFF
-            self._streams[key] = np.random.Generator(np.random.MT19937(seed))
+            gen = np.random.Generator(np.random.MT19937(seed))
+            register_stream(gen)
+            self._streams[key] = gen
         return self._streams[key]
+
+
+_allowed_generators: "weakref.WeakSet[np.random.Generator]" = weakref.WeakSet()
+_hook_enabled = False
+_orig_random_funcs: dict[str, object] = {}
+_orig_numpy_methods: dict[str, object] = {}
+_orig_secret_funcs: dict[str, object] = {}
+
+
+def register_stream(gen: np.random.Generator) -> None:
+    """Mark ``gen`` as an allowed RNG stream."""
+
+    _allowed_generators.add(gen)
+
+
+def _reject(*_: object, **__: object) -> None:
+    raise UncontrolledRandomError(
+        "Unmanaged random source: use RngManager.get_stream()"
+    )
+
+
+def activate_global_hooks() -> None:
+    """Globally reject uncontrolled RNG usage."""
+
+    global _hook_enabled
+    if _hook_enabled:
+        return
+    _hook_enabled = True
+
+    for name in [
+        "random",
+        "randrange",
+        "randint",
+        "choice",
+        "shuffle",
+        "uniform",
+        "gauss",
+        "betavariate",
+        "expovariate",
+        "gammavariate",
+        "lognormvariate",
+        "normalvariate",
+        "paretovariate",
+        "weibullvariate",
+        "sample",
+        "choices",
+    ]:
+        if hasattr(random, name):
+            _orig_random_funcs[name] = getattr(random, name)
+            setattr(random, name, _reject)
+
+    def wrap(method):
+        def wrapper(self, *a, **k):
+            if self not in _allowed_generators:
+                _reject()
+            return method(self, *a, **k)
+
+        return wrapper
+
+    for name in ["random", "normal", "choice", "integers", "shuffle"]:
+        if hasattr(np.random.Generator, name):
+            orig = getattr(np.random.Generator, name)
+            _orig_numpy_methods[name] = orig
+            setattr(np.random.Generator, name, wrap(orig))
+
+    for name in [
+        "choice",
+        "randbelow",
+        "randbits",
+        "token_bytes",
+        "token_hex",
+        "token_urlsafe",
+    ]:
+        if hasattr(secrets, name):
+            _orig_secret_funcs[name] = getattr(secrets, name)
+            setattr(secrets, name, _reject)
+
+
+def deactivate_global_hooks() -> None:
+    """Restore modules to their original state."""
+
+    global _hook_enabled
+    if not _hook_enabled:
+        return
+
+    for name, func in _orig_random_funcs.items():
+        setattr(random, name, func)
+    _orig_random_funcs.clear()
+
+    for name, method in _orig_numpy_methods.items():
+        setattr(np.random.Generator, name, method)
+    _orig_numpy_methods.clear()
+
+    for name, func in _orig_secret_funcs.items():
+        setattr(secrets, name, func)
+    _orig_secret_funcs.clear()
+
+    _hook_enabled = False


### PR DESCRIPTION
## Summary
- expose new RNG hook API in `traffic`
- implement `activate_global_hooks`/`deactivate_global_hooks`
- protect random sources with `UncontrolledRandomError`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68840070b7dc8331ba7281ced8ebda83