### PR TITLE
Switch to float event timestamps

### DIFF
--- a/simulateur_lora_sfrd/launcher/server.py
+++ b/simulateur_lora_sfrd/launcher/server.py
@@ -180,13 +180,13 @@ class NetworkServer:
             elif node.class_type.upper() == "C":
                 self.scheduler.schedule_class_c(node, at_time, frame, gw, priority=priority)
                 if self.simulator is not None:
-                    from .simulator import Event, EventType, _to_ns
+                    from .simulator import Event, EventType
 
                     eid = self.simulator.event_id_counter
                     self.simulator.event_id_counter += 1
                     heapq.heappush(
                         self.simulator.event_queue,
-                        Event(_to_ns(at_time), EventType.RX_WINDOW, eid, node.id),
+                        Event(at_time, EventType.RX_WINDOW, eid, node.id),
                     )
             else:
                 self.scheduler.schedule(node.id, at_time, frame, gw, priority=priority)
@@ -219,7 +219,7 @@ class NetworkServer:
             self.receive(event_id, node_id, gateway_id, rssi, frame)
             return
 
-        from .simulator import Event, EventType, _to_ns
+        from .simulator import Event, EventType
 
         arrival_time = (
             (at_time if at_time is not None else self.simulator.current_time)
@@ -235,7 +235,7 @@ class NetworkServer:
         self.pending_process[eid] = (event_id, node_id, gateway_id, rssi, frame)
         heapq.heappush(
             self.simulator.event_queue,
-            Event(_to_ns(arrival_time), EventType.SERVER_RX, eid, node_id),
+            Event(arrival_time, EventType.SERVER_RX, eid, node_id),
         )
 
     def _handle_network_arrival(self, eid: int) -> None:
@@ -243,7 +243,7 @@ class NetworkServer:
         info = self.pending_process.pop(eid, None)
         if not info:
             return
-        from .simulator import Event, EventType, _to_ns
+        from .simulator import Event, EventType
 
         process_time = self.simulator.current_time + self.process_delay
         new_id = self.simulator.event_id_counter
@@ -252,7 +252,7 @@ class NetworkServer:
         node_id = info[1]
         heapq.heappush(
             self.simulator.event_queue,
-            Event(_to_ns(process_time), EventType.SERVER_PROCESS, new_id, node_id),
+            Event(process_time, EventType.SERVER_PROCESS, new_id, node_id),
         )
 
     def _process_scheduled(self, eid: int) -> None:


### PR DESCRIPTION
## Summary
- keep simulation times as floating point seconds instead of integer nanoseconds
- update server helpers to enqueue events using float timestamps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68840440c760833192c5bb874ed23f73