### PR TITLE
Add lock-step Poisson mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ scénarios FLoRa. Voici la liste complète des options :
 - Les instants de transmission suivent strictement une loi exponentielle de
   moyenne `packet_interval` lorsque le mode `Random` est sélectionné.
 - `packets_to_send` : nombre de paquets émis **par nœud** avant arrêt (0 = infini).
+- `lock_step_poisson` : pré-génère une séquence Poisson réutilisée entre exécutions (nécessite `packets_to_send`).
 - `adr_node` / `adr_server` : active l'ADR côté nœud ou serveur.
 - `duty_cycle` : quota d'émission appliqué à chaque nœud (`None` pour désactiver).
 - `mobility` : active la mobilité aléatoire selon `mobility_speed`.

--- a/simulateur_lora_sfrd/launcher/node.py
+++ b/simulateur_lora_sfrd/launcher/node.py
@@ -223,6 +223,8 @@ class Node:
 
         # Poisson arrival process tracking
         self.arrival_queue: list[float] = []
+        self.precomputed_arrivals: list[float] | None = None
+        self._arrival_index: int = 0
         self.arrival_interval_sum: float = 0.0
         self.arrival_interval_count: int = 0
         self._last_arrival_time: float = 0.0
@@ -428,6 +430,23 @@ class Node:
             last += delta
             self.arrival_queue.append(last)
         self._last_arrival_time = last
+
+    def precompute_poisson_arrivals(
+        self,
+        rng: "np.random.Generator",
+        mean_interval: float,
+        count: int,
+    ) -> None:
+        """Generate ``count`` Poisson arrival times once and keep a copy."""
+
+        self.arrival_queue = []
+        self.precomputed_arrivals = None
+        self.arrival_interval_sum = 0.0
+        self.arrival_interval_count = 0
+        self._last_arrival_time = 0.0
+        self._arrival_index = 0
+        self.ensure_poisson_arrivals(float("inf"), rng, mean_interval, limit=count)
+        self.precomputed_arrivals = list(self.arrival_queue)
 
     # ------------------------------------------------------------------
     # LoRaWAN helper methods

--- a/tests/test_lockstep_poisson.py
+++ b/tests/test_lockstep_poisson.py
@@ -1,0 +1,31 @@
+from simulateur_lora_sfrd.launcher.simulator import Simulator
+
+
+def test_lockstep_poisson_sequences():
+    params = dict(
+        num_nodes=2,
+        num_gateways=1,
+        transmission_mode="Random",
+        packet_interval=5.0,
+        packets_to_send=5,
+        duty_cycle=0.01,
+        mobility=False,
+        seed=123,
+        lock_step_poisson=True,
+    )
+    sim1 = Simulator(**params)
+    sim1.run()
+    seqs1 = [tuple(n.precomputed_arrivals) for n in sim1.nodes]
+
+    sim2 = Simulator(**params)
+    sim2.run()
+    seqs2 = [tuple(n.precomputed_arrivals) for n in sim2.nodes]
+
+    assert seqs1 == seqs2
+
+    sim1.get_metrics()
+    sim2.get_metrics()
+
+    assert seqs1 == [tuple(n.precomputed_arrivals) for n in sim1.nodes]
+    assert seqs2 == [tuple(n.precomputed_arrivals) for n in sim2.nodes]
+


### PR DESCRIPTION
## Summary
- add new `lock_step_poisson` option to generate Poisson sequences once and reuse them
- store pre-computed intervals per node
- keep sequences unchanged when computing metrics
- document the new option
- test lock-step Poisson behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688404781dd08331a72b09a263871e01