### PR TITLE
Ensure poisson arrivals respect last airtime

### DIFF
--- a/simulateur_lora_sfrd/launcher/simulator.py
+++ b/simulateur_lora_sfrd/launcher/simulator.py
@@ -510,7 +510,10 @@ class Simulator:
                         node._last_arrival_time,
                         self.interval_rng,
                         self.packet_interval,
-                        self.packets_to_send if self.packets_to_send else None,
+                        min_interval=node.last_airtime,
+                        limit=(
+                            self.packets_to_send if self.packets_to_send else None
+                        ),
                     )
                 t0 = node.arrival_queue.pop(0)
             else:
@@ -884,7 +887,10 @@ class Simulator:
                                 node._last_arrival_time,
                                 self.interval_rng,
                                 self.packet_interval,
-                                self.packets_to_send if self.packets_to_send else None,
+                                min_interval=node.last_airtime,
+                                limit=(
+                                    self.packets_to_send if self.packets_to_send else None
+                                ),
                             )
                         next_time = node.arrival_queue.pop(0)
                     else:

--- a/tests/test_min_interval.py
+++ b/tests/test_min_interval.py
@@ -1,0 +1,20 @@
+from simulateur_lora_sfrd.launcher.simulator import Simulator
+
+
+def test_next_event_after_airtime():
+    sim = Simulator(
+        num_nodes=1,
+        num_gateways=1,
+        transmission_mode="Random",
+        packet_interval=1.0,
+        packets_to_send=5,
+        pure_poisson_mode=True,
+        mobility=False,
+        seed=1,
+    )
+    sim.run()
+    events = sim.events_log
+    for i in range(len(events) - 1):
+        airtime = events[i]["end_time"] - events[i]["start_time"]
+        delta = events[i + 1]["start_time"] - events[i]["start_time"]
+        assert delta >= airtime

--- a/tests/test_seed_stability.py
+++ b/tests/test_seed_stability.py
@@ -8,7 +8,9 @@ from simulateur_lora_sfrd.launcher.node import Node
 def _intervals_hash(seed: int, mean_interval: float = 1.0, count: int = 10000) -> str:
     rng = RngManager(seed).get_stream("traffic", 0)
     node = Node(0, 0, 0, 7, 14)
-    node.ensure_poisson_arrivals(1e9, rng, mean_interval, limit=count)
+    node.ensure_poisson_arrivals(
+        1e9, rng, mean_interval, min_interval=0.0, limit=count
+    )
     h = hashlib.sha256()
     last = 0.0
     for t in node.arrival_queue:


### PR DESCRIPTION
## Summary
- allow `Node.ensure_poisson_arrivals` to specify a minimum interval
- pass nodes' last airtime as this minimum interval when scheduling packets
- forward `min_interval` when precomputing Poisson arrivals
- add regression test for enforcing minimum interval
- update seed stability test for new argument

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68841545cf788331b53d6c233c2ac228