### PR TITLE
Add jitter support for Poisson arrivals

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ scénarios FLoRa. Voici la liste complète des options :
   passerelles.
 - `transmission_mode` : `Random` (émissions Poisson) ou `Periodic`.
 - `packet_interval` : moyenne ou période fixe entre transmissions (s).
-- `interval_variation` : coefficient de jitter appliqué à l'intervalle
-  exponentiel (0 par défaut pour coller au comportement FLoRa).
+- `interval_variation`: coefficient de jitter appliqué multiplicativement 
+  à l'intervalle exponentiel (0 par défaut pour coller au comportement FLoRa). L'intervalle est multiplié par `1 ± U` avec `U` échantillonné dans `[-interval_variation, interval_variation]`.
 - Les instants de transmission suivent strictement une loi exponentielle de
   moyenne `packet_interval` lorsque le mode `Random` est sélectionné.
 - `packets_to_send` : nombre de paquets émis **par nœud** avant arrêt (0 = infini).

--- a/simulateur_lora_sfrd/launcher/simulator.py
+++ b/simulateur_lora_sfrd/launcher/simulator.py
@@ -504,6 +504,7 @@ class Simulator:
                         self.interval_rng,
                         self.packet_interval,
                         self.packets_to_send,
+                        variation=self.interval_variation,
                     )
                 else:
                     node.ensure_poisson_arrivals(
@@ -511,6 +512,7 @@ class Simulator:
                         self.interval_rng,
                         self.packet_interval,
                         min_interval=node.last_airtime,
+                        variation=self.interval_variation,
                         limit=(
                             self.packets_to_send if self.packets_to_send else None
                         ),
@@ -888,6 +890,7 @@ class Simulator:
                                 self.interval_rng,
                                 self.packet_interval,
                                 min_interval=node.last_airtime,
+                                variation=self.interval_variation,
                                 limit=(
                                     self.packets_to_send if self.packets_to_send else None
                                 ),

--- a/tests/test_interval_asserts.py
+++ b/tests/test_interval_asserts.py
@@ -20,3 +20,5 @@ def test_node_poisson_assert():
         node.ensure_poisson_arrivals(10.0, rng, -5.0)
     with pytest.raises(AssertionError):
         node.ensure_poisson_arrivals(10.0, rng, 5)
+    with pytest.raises(AssertionError):
+        node.ensure_poisson_arrivals(10.0, rng, 5.0, variation=-1.0)

--- a/tests/test_interval_jitter.py
+++ b/tests/test_interval_jitter.py
@@ -1,0 +1,18 @@
+import numpy as np
+from traffic.exponential import sample_interval
+from simulateur_lora_sfrd.launcher.node import Node
+
+
+def test_jitter_multiplier():
+    rng = np.random.Generator(np.random.MT19937(0))
+    node = Node(0, 0, 0, 7, 20)
+    node.ensure_poisson_arrivals(10.0, rng, 1.0, variation=0.5, limit=1)
+    delta = node.arrival_queue[0]
+
+    rng2 = np.random.Generator(np.random.MT19937(0))
+    base = sample_interval(1.0, rng2)
+    factor = 1.0 + (2.0 * rng2.random() - 1.0) * 0.5
+    if factor < 0.0:
+        factor = 0.0
+    expected = base * factor
+    assert abs(delta - expected) < 1e-12


### PR DESCRIPTION
## Summary
- implement multiplicative jitter in `Node.ensure_poisson_arrivals`
- propagate jitter parameter from `Simulator`
- document the option in README
- test argument validation and jitter calculation

## Testing
- `PYTHONPATH=. pytest -q tests/test_interval_asserts.py tests/test_interval_jitter.py`

------
https://chatgpt.com/codex/tasks/task_e_68841895dea083319a92889f1ebe5e3d