### PR TITLE
Implement FLoRa first packet delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,10 @@ scénarios FLoRa. Voici la liste complète des options :
   passerelles.
 - `transmission_mode` : `Random` (émissions Poisson) ou `Periodic`.
 - `packet_interval` : moyenne ou période fixe entre transmissions (s).
-- `interval_variation`: coefficient de jitter appliqué multiplicativement 
+- `first_packet_interval` : moyenne exponentielle appliquée uniquement au
+  premier envoi (`None` pour reprendre `packet_interval`).
+- `first_packet_min_delay` : délai minimal avant la première transmission (s).
+- `interval_variation`: coefficient de jitter appliqué multiplicativement
   à l'intervalle exponentiel (0 par défaut pour coller au comportement FLoRa). L'intervalle est multiplié par `1 ± U` avec `U` échantillonné dans `[-interval_variation, interval_variation]`.
 - Les instants de transmission suivent strictement une loi exponentielle de
   moyenne `packet_interval` lorsque le mode `Random` est sélectionné.

--- a/simulateur_lora_sfrd/launcher/config_loader.py
+++ b/simulateur_lora_sfrd/launcher/config_loader.py
@@ -106,3 +106,18 @@ def parse_flora_interval(path: str | Path) -> float | None:
     if match:
         return float(match.group(1))
     return None
+
+
+def parse_flora_first_interval(path: str | Path) -> float | None:
+    """Return the mean delay before the first packet defined in a FLoRa INI.
+
+    The INI parameter ``timeToFirstPacket`` is expected in the form
+    ``exponential(<value>s)``. When present, ``<value>`` is returned as a float.
+    ``None`` is returned if the parameter cannot be found.
+    """
+
+    text = Path(path).read_text()
+    match = re.search(r"timeToFirstPacket\s*=\s*exponential\((\d+(?:\.\d+)?)s\)", text)
+    if match:
+        return float(match.group(1))
+    return None

--- a/tests/test_first_packet_delay.py
+++ b/tests/test_first_packet_delay.py
@@ -1,0 +1,14 @@
+from simulateur_lora_sfrd.launcher.simulator import Simulator, EventType
+
+
+def test_first_packet_respects_delay():
+    sim = Simulator(
+        num_nodes=5,
+        num_gateways=1,
+        flora_mode=True,
+        mobility=False,
+        packets_to_send=1,
+        seed=42,
+    )
+    start_times = [e.time for e in sim.event_queue if e.type == EventType.TX_START]
+    assert all(t >= 5.0 for t in start_times)


### PR DESCRIPTION
## Summary
- support `timeToFirstPacket` parsing
- allow `Simulator` to configure first packet interval and delay
- enforce a 5s delay in FLoRa mode when scheduling first packets
- document the new options
- test that first packets respect the FLoRa delay

## Testing
- `python -m py_compile simulateur_lora_sfrd/launcher/config_loader.py simulateur_lora_sfrd/launcher/simulator.py tests/test_first_packet_delay.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'simulateur_lora_sfrd' and missing numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6884235b49f083319d681ee019f83816