### PR TITLE
Add FLoRa first-packet interval parsing

### DIFF
--- a/simulateur_lora_sfrd/launcher/config_loader.py
+++ b/simulateur_lora_sfrd/launcher/config_loader.py
@@ -106,3 +106,31 @@ def parse_flora_interval(path: str | Path) -> float | None:
     if match:
         return float(match.group(1))
     return None
+
+
+def parse_flora_first_interval(path: str | Path) -> float | None:
+    """Return the mean initial delay defined in a FLoRa INI file.
+
+    The parameter ``timeToFirstPacket`` follows the same format as
+    ``timeToNextPacket`` and is expressed as ``exponential(<value>s)``.  The
+    returned value corresponds to ``<value>`` as a float or ``None`` if the
+    parameter is missing.
+    """
+
+    text = Path(path).read_text()
+    match = re.search(r"timeToFirstPacket\s*=\s*exponential\((\d+(?:\.\d+)?)s\)", text)
+    if match:
+        return float(match.group(1))
+    return None
+
+
+def parse_flora_intervals(path: str | Path) -> tuple[float | None, float | None]:
+    """Return both packet intervals defined in ``path``.
+
+    The tuple contains ``(timeToNextPacket, timeToFirstPacket)``.  Each value is
+    ``None`` when the corresponding parameter is absent.
+    """
+
+    next_i = parse_flora_interval(path)
+    first_i = parse_flora_first_interval(path)
+    return next_i, first_i

--- a/tests/test_flora_interval.py
+++ b/tests/test_flora_interval.py
@@ -1,12 +1,19 @@
 from pathlib import Path
 
 from simulateur_lora_sfrd.launcher.simulator import Simulator
-from simulateur_lora_sfrd.launcher.config_loader import parse_flora_interval
+from simulateur_lora_sfrd.launcher.config_loader import (
+    parse_flora_interval,
+    parse_flora_first_interval,
+    parse_flora_intervals,
+)
 
 
 def test_flora_ini_interval_parsing():
     ini_path = Path('flora-master/simulations/examples/n100-gw1.ini')
-    mean_f = parse_flora_interval(ini_path)
-    assert mean_f is not None
+    next_i = parse_flora_interval(ini_path)
+    first_i = parse_flora_first_interval(ini_path)
+    both = parse_flora_intervals(ini_path)
+    assert next_i is not None and first_i is not None
+    assert both == (next_i, first_i)
     sim = Simulator(flora_mode=True, config_file=str(ini_path))
-    assert sim.packet_interval == mean_f
+    assert sim.packet_interval == next_i


### PR DESCRIPTION
## Summary
- expose first packet delay from FLoRa configuration files
- parse both packet intervals via new helpers
- test parsing of timeToFirstPacket and timeToNextPacket

## Testing
- `PYTHONPATH=/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages:. pytest -q tests/test_flora_interval.py`

------
https://chatgpt.com/codex/tasks/task_e_688423690b288331a6bd5781b170aca5