### PR TITLE
Add FLoRa first packet delay parsing

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/simulateur_lora_sfrd/architecture.py
+++ b/simulateur_lora_sfrd/architecture.py
@@ -37,7 +37,7 @@ class SimulationConfig:
     @classmethod
     def from_ini(cls, path: str) -> "SimulationConfig":
         """Charge une configuration INI ou JSON compatible FLoRa."""
-        ndata, gdata = load_config(path)
+        ndata, gdata, _, _ = load_config(path)
         nodes = [NodeConfig(**nd) for nd in ndata]
         gws = [GatewayConfig(**gw) for gw in gdata]
         return cls(nodes, gws)

--- a/simulateur_lora_sfrd/launcher/simulator.py
+++ b/simulateur_lora_sfrd/launcher/simulator.py
@@ -379,21 +379,17 @@ class Simulator:
         cfg_nodes = None
         cfg_gateways = None
         if config_file:
-            from .config_loader import (
-                load_config,
-                parse_flora_interval,
-                parse_flora_first_interval,
-            )
+            from .config_loader import load_config
 
-            cfg_nodes, cfg_gateways = load_config(config_file)
+            cfg_nodes, cfg_gateways, mean_interval, first_mean = load_config(
+                config_file
+            )
             if cfg_gateways:
                 self.num_gateways = len(cfg_gateways)
             if cfg_nodes:
                 self.num_nodes = len(cfg_nodes)
-            mean_interval = parse_flora_interval(config_file)
             if mean_interval is not None:
                 self.packet_interval = mean_interval
-            first_mean = parse_flora_first_interval(config_file)
             if first_mean is not None:
                 self.first_packet_interval = first_mean
 

--- a/tests/test_flora_interval.py
+++ b/tests/test_flora_interval.py
@@ -1,12 +1,21 @@
 from pathlib import Path
 
 from simulateur_lora_sfrd.launcher.simulator import Simulator
-from simulateur_lora_sfrd.launcher.config_loader import parse_flora_interval
+from simulateur_lora_sfrd.launcher.config_loader import (
+    parse_flora_interval,
+    parse_flora_first_interval,
+    load_config,
+)
 
 
 def test_flora_ini_interval_parsing():
     ini_path = Path('flora-master/simulations/examples/n100-gw1.ini')
-    mean_f = parse_flora_interval(ini_path)
-    assert mean_f is not None
+    next_mean = parse_flora_interval(ini_path)
+    first_mean = parse_flora_first_interval(ini_path)
+    assert next_mean is not None and first_mean is not None
+    nodes, gws, next_from_load, first_from_load = load_config(ini_path)
+    assert next_from_load == next_mean
+    assert first_from_load == first_mean
     sim = Simulator(flora_mode=True, config_file=str(ini_path))
-    assert sim.packet_interval == mean_f
+    assert sim.packet_interval == next_mean
+    assert sim.first_packet_interval == first_mean


### PR DESCRIPTION
## Summary
- expose both `timeToNextPacket` and `timeToFirstPacket` when loading FLoRa INIs
- update simulator and architecture to handle new return signature
- parse first-packet delay in loader
- extend unit test for FLoRa intervals
- limit pytest discovery to top-level tests

## Testing
- `python -m py_compile simulateur_lora_sfrd/launcher/config_loader.py simulateur_lora_sfrd/architecture.py simulateur_lora_sfrd/launcher/simulator.py`
- `pytest tests/test_flora_interval.py -q` *(fails: ModuleNotFoundError: No module named 'simulateur_lora_sfrd')*

------
https://chatgpt.com/codex/tasks/task_e_68842632df7483318130eab4ed5f5c46