### PR TITLE
Add FLoRa packet interval test

### DIFF
--- a/tests/test_flora_packet_interval.py
+++ b/tests/test_flora_packet_interval.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from simulateur_lora_sfrd.launcher.simulator import Simulator
+from simulateur_lora_sfrd.launcher.config_loader import parse_flora_interval
+
+
+def test_flora_packet_interval():
+    ini = Path('flora-master/simulations/examples/n100-gw1.ini')
+    mean_interval = parse_flora_interval(ini)
+    assert mean_interval is not None
+
+    sim = Simulator(
+        flora_mode=True,
+        config_file=str(ini),
+        packets_to_send=300,
+        mobility=False,
+        seed=0,
+    )
+    sim.run()
+    metrics = sim.get_metrics()
+    assert abs(metrics["avg_arrival_interval_s"] - mean_interval) / mean_interval < 0.01


### PR DESCRIPTION
## Summary
- add test that verifies packet intervals with a FLoRa INI configuration

## Testing
- `python -m pytest tests/test_flora_packet_interval.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_6884889e5a188331aff0f19058c5e2b8