### PR TITLE
Clarify exponential interval handling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ scénarios FLoRa. Voici la liste complète des options :
   à l'intervalle exponentiel (0 par défaut pour coller au comportement FLoRa). L'intervalle est multiplié par `1 ± U` avec `U` échantillonné dans `[-interval_variation, interval_variation]`.
 - Les instants de transmission suivent strictement une loi exponentielle de
   moyenne `packet_interval` lorsque le mode `Random` est sélectionné.
+- Les échantillons dont la durée est inférieure à l'airtime du paquet
+  précédent sont ignorés, comme dans `SimpleLoRaApp.cc`. Cette logique est
+  implémentée par `ensure_poisson_arrivals` à partir de la valeur extraite via
+  `parse_flora_interval`.
 - `packets_to_send` : nombre de paquets émis **par nœud** avant arrêt (0 = infini).
 - `lock_step_poisson` : pré-génère une séquence Poisson réutilisée entre exécutions (nécessite `packets_to_send`).
 - `adr_node` / `adr_server` : active l'ADR côté nœud ou serveur.


### PR DESCRIPTION
## Summary
- update simulator options documentation around interval generation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6884889fbc10833187ba96d096939547