### PR TITLE
Fix Poisson arrival logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Significantly increased channel degradation in `adr_standard_1` for simulator validation.
-- Send interval distribution now uses a strict exponential model without any cap to match FLoRa.
+- Send interval distribution now follows a strict exponential law and timestamps are only postponed when a transmission is still ongoing.
 
 ## [5.0] - 2025-07-24
 ### Added

--- a/README.md
+++ b/README.md
@@ -165,12 +165,12 @@ scénarios FLoRa. Voici la liste complète des options :
 - `first_packet_min_delay` : délai minimal avant la première transmission (s).
 - `interval_variation`: coefficient de jitter appliqué multiplicativement
   à l'intervalle exponentiel (0 par défaut pour coller au comportement FLoRa). L'intervalle est multiplié par `1 ± U` avec `U` échantillonné dans `[-interval_variation, interval_variation]`.
-- Les instants de transmission suivent strictement une loi exponentielle de
-  moyenne `packet_interval` lorsque le mode `Random` est sélectionné.
-- Les échantillons dont la durée est inférieure à l'airtime du paquet
-  précédent sont ignorés, comme dans `SimpleLoRaApp.cc`. Cette logique est
-  implémentée par `ensure_poisson_arrivals` à partir de la valeur extraite via
-  `parse_flora_interval`.
+ - Les instants de transmission suivent strictement une loi exponentielle de
+   moyenne `packet_interval` lorsque le mode `Random` est sélectionné.
+ - Tous les échantillons sont conservés ; si une transmission est encore en
+   cours, la date tirée est simplement repoussée après son terme. Cette logique
+   est implémentée par `ensure_poisson_arrivals` et `schedule_event` à partir de
+   la valeur extraite via `parse_flora_interval`.
 - `packets_to_send` : nombre de paquets émis **par nœud** avant arrêt (0 = infini).
 - `lock_step_poisson` : pré-génère une séquence Poisson réutilisée entre exécutions (nécessite `packets_to_send`).
 - `adr_node` / `adr_server` : active l'ADR côté nœud ou serveur.

--- a/simulateur_lora_sfrd/launcher/node.py
+++ b/simulateur_lora_sfrd/launcher/node.py
@@ -404,8 +404,8 @@ class Node:
     ) -> None:
         """Generate Poisson arrival times up to ``up_to`` seconds.
 
-        ``min_interval`` enforces a minimal delay between samples by
-        discarding draws below this threshold. ``variation`` applies a
+        ``min_interval`` is retained for backward compatibility but no
+        longer filters sampled intervals. ``variation`` applies a
         multiplicative jitter factor to each sampled interval.
         """
         assert isinstance(mean_interval, float) and mean_interval > 0, (
@@ -427,13 +427,6 @@ class Node:
                 if factor < 0.0:
                     factor = 0.0
                 delta *= factor
-            while delta < min_interval:
-                delta = sample_interval(mean_interval, rng)
-                if variation > 0.0:
-                    factor = 1.0 + (2.0 * rng.random() - 1.0) * variation
-                    if factor < 0.0:
-                        factor = 0.0
-                    delta *= factor
             if self._warmup_remaining > 0:
                 self._warmup_remaining -= 1
             else:

--- a/simulateur_lora_sfrd/launcher/simulator.py
+++ b/simulateur_lora_sfrd/launcher/simulator.py
@@ -573,6 +573,9 @@ class Simulator:
         if not node.alive:
             return
         requested_time = time
+        if node.current_end_time is not None and time < node.current_end_time:
+            time = node.current_end_time
+            reason = "overlap"
         event_id = self.event_id_counter
         self.event_id_counter += 1
         if self.duty_cycle_manager and not self.pure_poisson_mode:
@@ -904,7 +907,6 @@ class Simulator:
                                 node._last_arrival_time,
                                 self.interval_rng,
                                 self.packet_interval,
-                                min_interval=node.last_airtime,
                                 variation=self.interval_variation,
                                 limit=(
                                     self.packets_to_send if self.packets_to_send else None
@@ -918,7 +920,7 @@ class Simulator:
                         node._last_arrival_time = next_time
                     self.schedule_event(
                         node,
-                        next_time,
+                        max(next_time, self.current_time),
                         reason="poisson"
                         if self.transmission_mode.lower() == "random"
                         else "periodic",

--- a/tests/test_degraded_channel_interval.py
+++ b/tests/test_degraded_channel_interval.py
@@ -1,0 +1,23 @@
+from simulateur_lora_sfrd.launcher.simulator import Simulator
+from simulateur_lora_sfrd.launcher.adr_standard_1 import apply as apply_adr
+
+
+def test_interval_with_degraded_channel():
+    mean_interval = 2.0
+    packets = 1000
+    sim = Simulator(
+        num_nodes=1,
+        num_gateways=1,
+        transmission_mode="Random",
+        packet_interval=mean_interval,
+        packets_to_send=packets,
+        pure_poisson_mode=True,
+        mobility=False,
+        seed=1,
+    )
+    apply_adr(sim, degrade_channel=True)
+    sim.run()
+    node = sim.nodes[0]
+    average = node._last_arrival_time / node.packets_sent
+    assert node.packets_sent == packets
+    assert abs(average - mean_interval) / mean_interval < 0.02


### PR DESCRIPTION
## Summary
- keep exponential intervals without resampling
- prevent overlapping transmissions in `schedule_event`
- schedule from Poisson queue without minimum interval
- add test for degraded channel interval
- document new Poisson behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68848b318ff88331b04ad3ebfec4feb2