### PR TITLE
Add first_interval option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ fournies dans l'INI de FLoRa.
 4. **Exécutez des simulations en ligne de commande :**
    ```bash
    python run.py --nodes 30 --gateways 1 --mode Random --interval 10 --steps 100 --output résultats.csv
-   python run.py --nodes 20 --mode Random --interval 15
+   python run.py --nodes 20 --mode Random --interval 15 --first-interval 5
    python run.py --nodes 5 --mode Periodic --interval 10
    ```
     Ajoutez l'option `--seed` pour reproduire exactement le placement des nœuds


### PR DESCRIPTION
## Summary
- allow specifying a first packet interval different from the steady interval
- document the new `--first-interval` argument

## Testing
- `pytest -q` *(fails: ModuleNotFoundError due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68848f3b94f88331baa52582ced9edca