### PR TITLE
Add interval support to write_flora_ini

### DIFF
--- a/simulateur_lora_sfrd/launcher/config_loader.py
+++ b/simulateur_lora_sfrd/launcher/config_loader.py
@@ -77,7 +77,12 @@ def load_config(
 
 
 def write_flora_ini(
-    nodes: list[dict], gateways: list[dict], path: str | Path
+    nodes: list[dict],
+    gateways: list[dict],
+    path: str | Path,
+    *,
+    next_interval: float | None = None,
+    first_interval: float | None = None,
 ) -> None:
     """Write ``nodes`` and ``gateways`` positions to a FLoRa compatible INI.
 
@@ -90,6 +95,12 @@ def write_flora_ini(
         Each dictionary must contain ``x`` and ``y`` coordinates.
     path : str or Path
         Destination file.
+    next_interval : float, optional
+        Mean delay between packets. When set, ``timeToNextPacket`` is appended to
+        the INI file.
+    first_interval : float, optional
+        Mean delay before the first packet. When set,
+        ``timeToFirstPacket`` is appended to the INI file.
     """
 
     cp = configparser.ConfigParser()
@@ -103,6 +114,10 @@ def write_flora_ini(
     }
     with open(path, "w") as f:
         cp.write(f)
+        if first_interval is not None:
+            f.write(f"timeToFirstPacket = exponential({first_interval}s)\n")
+        if next_interval is not None:
+            f.write(f"timeToNextPacket = exponential({next_interval}s)\n")
 
 
 def parse_flora_interval(path: str | Path) -> float | None:

--- a/tests/test_write_flora_ini.py
+++ b/tests/test_write_flora_ini.py
@@ -1,0 +1,14 @@
+from simulateur_lora_sfrd.launcher.config_loader import (
+    write_flora_ini,
+    parse_flora_interval,
+    parse_flora_first_interval,
+)
+
+
+def test_write_intervals(tmp_path):
+    ini = tmp_path / "scenario.ini"
+    nodes = [{"x": 1.0, "y": 2.0}]
+    gateways = [{"x": 3.0, "y": 4.0}]
+    write_flora_ini(nodes, gateways, ini, next_interval=7.5, first_interval=1.5)
+    assert parse_flora_interval(ini) == 7.5
+    assert parse_flora_first_interval(ini) == 1.5


### PR DESCRIPTION
## Summary
- extend `write_flora_ini` to optionally write packet intervals
- test optional packet interval writing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError - dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68848f40ff848331a6b9d788d6837229