### PR TITLE
Display first packet delay in dashboard

### DIFF
--- a/simulateur_lora_sfrd/launcher/dashboard.py
+++ b/simulateur_lora_sfrd/launcher/dashboard.py
@@ -183,6 +183,12 @@ min_interference_input = pn.widgets.FloatInput(
     name="Min interference (s)", value=5.0, step=0.1, start=0.0
 )
 min_interference_input.disabled = True
+# Affichage en lecture seule du délai minimal avant le premier envoi
+first_packet_delay_display = pn.widgets.FloatInput(
+    name="Délai 1er paquet (s)",
+    value=5.0 if flora_mode_toggle.value else 0.0,
+    disabled=True,
+)
 # --- Paramètres supplémentaires ---
 battery_capacity_input = pn.widgets.FloatInput(
     name="Capacité batterie (J)", value=0.0, step=10.0, start=0.0
@@ -783,6 +789,8 @@ def setup_simulation(seed_offset: int = 0):
         phy_model="flora" if flora_mode_toggle.value else "omnet",
     )
 
+    first_packet_delay_display.value = sim.first_packet_min_delay
+
     if config_path:
         try:
             os.unlink(config_path)
@@ -1279,6 +1287,7 @@ def on_flora_toggle(event):
         detection_threshold_input.value = -110.0
         # En mode FLoRa, la durée minimale d'interférence est fixée à 5 s
         min_interference_input.value = 5.0
+        first_packet_delay_display.value = 5.0
         detection_threshold_input.disabled = True
         min_interference_input.disabled = True
         flora_mode_toggle.button_type = "primary"
@@ -1286,6 +1295,7 @@ def on_flora_toggle(event):
         detection_threshold_input.disabled = False
         min_interference_input.disabled = False
         flora_mode_toggle.button_type = "default"
+        first_packet_delay_display.value = 0.0
 
 flora_mode_toggle.param.watch(on_flora_toggle, "value")
 
@@ -1368,6 +1378,7 @@ controls = pn.WidgetBox(
     flora_mode_toggle,
     detection_threshold_input,
     min_interference_input,
+    first_packet_delay_display,
     battery_capacity_input,
     payload_size_input,
     node_class_select,


### PR DESCRIPTION
## Summary
- show the first packet minimal delay enforced by FLoRa in a dedicated read-only widget
- refresh the delay display when toggling FLoRa mode and after each simulator creation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68848f4c2c94833198b0eb6511739494