### PR TITLE
Add first packet interval tests and features

### DIFF
--- a/simulateur_lora_sfrd/launcher/dashboard.py
+++ b/simulateur_lora_sfrd/launcher/dashboard.py
@@ -103,6 +103,9 @@ def _validate_positive_inputs() -> bool:
     if float(interval_input.value) <= 0:
         export_message.object = "⚠️ L'intervalle doit être supérieur à 0 !"
         return False
+    if float(first_interval_input.value) <= 0:
+        export_message.object = "⚠️ Le 1er intervalle doit être supérieur à 0 !"
+        return False
     return True
 
 
@@ -114,6 +117,7 @@ mode_select = pn.widgets.RadioButtonGroup(
     name="Mode d'émission", options=["Aléatoire", "Périodique"], value="Aléatoire"
 )
 interval_input = pn.widgets.FloatInput(name="Intervalle moyen (s)", value=100.0, step=1.0, start=0.1)
+first_interval_input = pn.widgets.FloatInput(name="1er intervalle (s)", value=100.0, step=1.0, start=0.1)
 packets_input = pn.widgets.IntInput(
     name="Nombre de paquets par nœud (0=infin)", value=80, step=1, start=0
 )
@@ -515,6 +519,21 @@ def on_mode_change(event):
 mode_select.param.watch(on_mode_change, "value")
 
 
+# --- Synchronisation des intervalles ---
+def _sync_from_interval(event):
+    if first_interval_input.value != event.new:
+        first_interval_input.value = event.new
+
+
+def _sync_from_first(event):
+    if interval_input.value != event.new:
+        interval_input.value = event.new
+
+
+interval_input.param.watch(_sync_from_interval, "value")
+first_interval_input.param.watch(_sync_from_first, "value")
+
+
 # --- Sélection du profil ADR ---
 def _update_adr_badge(name: str) -> None:
     adr_active_badge.object = (
@@ -754,6 +773,7 @@ def setup_simulation(seed_offset: int = 0):
         area_size=float(area_input.value),
         transmission_mode="Random" if mode_select.value == "Aléatoire" else "Periodic",
         packet_interval=float(interval_input.value),
+        first_packet_interval=float(first_interval_input.value),
         packets_to_send=int(packets_input.value),
         adr_node=adr_node_checkbox.value,
         adr_server=adr_server_checkbox.value,
@@ -845,6 +865,7 @@ def setup_simulation(seed_offset: int = 0):
     area_input.disabled = True
     mode_select.disabled = True
     interval_input.disabled = True
+    first_interval_input.disabled = True
     packets_input.disabled = True
     adr_node_checkbox.disabled = True
     adr_server_checkbox.disabled = True
@@ -975,6 +996,7 @@ def on_stop(event):
     area_input.disabled = False
     mode_select.disabled = False
     interval_input.disabled = False
+    first_interval_input.disabled = False
     packets_input.disabled = False
     adr_node_checkbox.disabled = False
     adr_server_checkbox.disabled = False
@@ -1344,6 +1366,7 @@ controls = pn.WidgetBox(
     area_input,
     mode_select,
     interval_input,
+    first_interval_input,
     packets_input,
     seed_input,
     num_runs_input,

--- a/tests/test_first_interval_cli_dashboard.py
+++ b/tests/test_first_interval_cli_dashboard.py
@@ -1,0 +1,55 @@
+import pytest
+
+from simulateur_lora_sfrd.launcher.simulator import Simulator
+from simulateur_lora_sfrd import run
+
+
+def test_simulator_interval_none_uses_packet_interval():
+    sim = Simulator(
+        num_nodes=1,
+        num_gateways=1,
+        packet_interval=5.0,
+        first_packet_interval=None,
+        packets_to_send=1,
+        mobility=False,
+        seed=0,
+    )
+    assert sim.packet_interval == 5.0
+    assert sim.first_packet_interval == 5.0
+
+
+def test_cli_first_interval_overrides(monkeypatch):
+    captured = {}
+
+    def fake_simulate(nodes, gateways, mode, interval, first_interval, steps, channels=1, *, fine_fading_std=0.0, noise_std=0.0, debug_rx=False, phy_model="omnet", rng_manager=None):
+        captured["interval"] = interval
+        captured["first_interval"] = first_interval
+        captured["steps"] = steps
+        return (0, 0, 0, 0, 0, 0)
+
+    monkeypatch.setattr(run, "simulate", fake_simulate)
+    run.main([
+        "--nodes",
+        "1",
+        "--gateways",
+        "1",
+        "--steps",
+        "5",
+        "--interval",
+        "2",
+        "--first-interval",
+        "7",
+    ])
+    assert captured["interval"] == 2.0
+    assert captured["first_interval"] == 7.0
+
+
+pn = pytest.importorskip("panel")
+dashboard = pytest.importorskip("simulateur_lora_sfrd.launcher.dashboard")
+
+
+def test_dashboard_inputs_synced():
+    dashboard.interval_input.value = 8.0
+    assert dashboard.first_interval_input.value == 8.0
+    dashboard.first_interval_input.value = 12.0
+    assert dashboard.interval_input.value == 12.0


### PR DESCRIPTION
## Summary
- allow specifying `--first-interval` for CLI
- expose a `first_interval_input` in dashboard and keep it in sync with `interval_input`
- add simulator unit tests for first interval behaviour and dashboard/CLI coverage

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68848f52f4d48331ac759b6f7c0d16c3