### PR TITLE
Log effective intervals for metrics

### DIFF
--- a/tests/test_effective_interval.py
+++ b/tests/test_effective_interval.py
@@ -1,0 +1,19 @@
+from simulateur_lora_sfrd.launcher.simulator import Simulator
+
+
+def test_effective_avg_interval():
+    sim = Simulator(
+        num_nodes=1,
+        num_gateways=1,
+        transmission_mode="Random",
+        packet_interval=2.0,
+        packets_to_send=50,
+        duty_cycle=0.01,
+        pure_poisson_mode=True,
+        mobility=False,
+        dump_intervals=False,
+        seed=0,
+    )
+    sim.run()
+    metrics = sim.get_metrics()
+    assert abs(metrics["avg_arrival_interval_s"] - 2.0) / 2.0 < 0.1

--- a/tests/test_poisson_independence.py
+++ b/tests/test_poisson_independence.py
@@ -10,6 +10,7 @@ def test_duty_cycle_keeps_mean_interval():
         packets_to_send=30,
         duty_cycle=0.01,
         mobility=False,
+        pure_poisson_mode=True,
         seed=123,
     )
     sim.run()
@@ -26,6 +27,7 @@ def test_collisions_keep_mean_interval():
         packets_to_send=200,
         duty_cycle=0.01,
         mobility=False,
+        pure_poisson_mode=True,
         seed=42,
     )
     sim.run()


### PR DESCRIPTION
## Summary
- always record scheduled intervals
- compute mean arrival interval from those effective times when available
- test metric calculation using effective times
- adjust Poisson independence tests for pure Poisson mode

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688497d7b0208331b29db5b408015589