### PR TITLE
Fix test imports

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,14 @@
 import random
+import os
+import sys
 import pytest
+
+# Ensure the project root is on the module search path when the package is not
+# installed. This allows ``import simulateur_lora_sfrd`` to succeed during
+# test collection without requiring an editable installation.
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
 
 @pytest.fixture(autouse=True)
 def _set_seed():


### PR DESCRIPTION
## Summary
- fix PYTHONPATH issues so tests find simulateur_lora_sfrd package
- add root to `sys.path` in `tests/conftest.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68849efdf7b883319b911da5e6ad8ea9