### PR TITLE
Adjust FLoRa mode default intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ avec l'option `flora_mode=True`. Ce mode applique automatiquement :
 - un shadowing de `σ = 3.57` dB ;
 - un seuil de détection d'environ `-110` dBm.
 - l'utilisation automatique des formules FLoRa (`phy_model="flora" ou "flora_full"`).
+- un intervalle moyen de `1000` s appliqué si aucun intervalle n'est spécifié.
 
 ### Équations FLoRa de perte de parcours et de PER
 

--- a/simulateur_lora_sfrd/launcher/dashboard.py
+++ b/simulateur_lora_sfrd/launcher/dashboard.py
@@ -113,7 +113,7 @@ area_input = pn.widgets.FloatInput(name="Taille de l'aire (m)", value=1000.0, st
 mode_select = pn.widgets.RadioButtonGroup(
     name="Mode d'émission", options=["Aléatoire", "Périodique"], value="Aléatoire"
 )
-interval_input = pn.widgets.FloatInput(name="Intervalle moyen (s)", value=100.0, step=1.0, start=0.1)
+interval_input = pn.widgets.FloatInput(name="Intervalle moyen (s)", value=1000.0, step=1.0, start=0.1)
 first_packet_input = pn.widgets.FloatInput(
     name="Intervalle premier paquet (s)",
     value=interval_input.value,

--- a/simulateur_lora_sfrd/launcher/simulator.py
+++ b/simulateur_lora_sfrd/launcher/simulator.py
@@ -195,6 +195,9 @@ class Simulator:
         :param lock_step_poisson: Prégénère la séquence Poisson une seule fois et la réutilise.
         """
         # Paramètres de simulation
+        if flora_mode and packet_interval == 60.0 and first_packet_interval is None:
+            packet_interval = first_packet_interval = 1000.0
+
         self.num_nodes = num_nodes
         self.num_gateways = num_gateways
         self.area_size = area_size

--- a/tests/test_flora_defaults.py
+++ b/tests/test_flora_defaults.py
@@ -1,0 +1,7 @@
+from simulateur_lora_sfrd.launcher.simulator import Simulator
+
+
+def test_default_intervals_flora_mode():
+    sim = Simulator(flora_mode=True)
+    assert sim.packet_interval == 1000.0
+    assert sim.first_packet_interval == 1000.0


### PR DESCRIPTION
## Summary
- default both intervals to 1000s when `flora_mode` is enabled with no overrides
- show 1000s defaults in dashboard
- document the behaviour in README
- test the new default values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884a667892c8331aefbc636bffa30c2