### PR TITLE
Add LoRaWAN feature comparison docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Simulateur Réseau LoRa (Python 3.10+)
 
 Bienvenue ! Ce projet est un **simulateur complet de réseau LoRa**, inspiré du fonctionnement de FLoRa sous OMNeT++, codé entièrement en Python.
-
+Pour un apercu des differences avec FLoRa, consultez docs/lorawan_features.md.
 ## 🛠️ Installation
 
 1. **Clonez ou téléchargez** le projet.

--- a/docs/lorawan_features.md
+++ b/docs/lorawan_features.md
@@ -1,0 +1,49 @@
+# Comparaison des fonctionnalités LoRaWAN
+
+Ce document résume les différences entre la simulation FLoRa d'origine
+(`flora-master/src/LoRa/`) et l'implémentation Python présente dans `launcher/`.
+
+## Fonctionnalités prises en charge par FLoRa
+
+- Gestion basique des trames LoRa avec accusés de réception.
+- Évaluation de l'ADR côté serveur via `NetworkServerApp::evaluateADR`.
+- Types de messages ``JOIN_REQUEST`` et ``JOIN_REPLY`` définis dans
+  `LoRaAppPacket.msg`.
+- Aucune prise en charge intégrée des classes B ou C.
+- Pas de chiffrement ou d'authentification des messages.
+
+## Fonctionnalités de l'implémentation Python
+
+- Support complet du protocole LoRaWAN : frames ``LoRaWANFrame``,
+  chiffrement AES et calcul du MIC.
+- Gestion des classes A, B et C dans `server.py` et `node.py` (beacons,
+  ping slots, réception continue).
+- Implémentation de nombreuses commandes MAC
+  (``LinkADRReq``, ``DeviceTimeReq``, ``PingSlotChannelReq``…).
+- Procédure d’activation OTAA via un serveur de join (`JoinServer`).
+- Historique SNR et ajustement ADR conforme à la spécification.
+
+## Fonctionnalités équivalentes
+
+- Les deux versions permettent l’émission de messages et un accusé de
+  réception optionnel.
+- Les performances énergétiques s’appuient sur le profil FLoRa dans les
+  deux cas.
+- Un mécanisme d’ADR est disponible de part et d’autre, bien que
+  l’algorithme diffère légèrement.
+
+## Fonctionnalités propres à la version Python
+
+- Sécurité LoRaWAN (chiffrement des charges utiles et MIC).
+- Gestion explicite des classes B et C avec planification des downlinks.
+- Grand nombre de commandes MAC supplémentaires.
+- Activation OTAA avec dérivation dynamique des clés.
+
+## Éléments pouvant affecter la comparaison des métriques
+
+- L’ajout du chiffrement et des en-têtes LoRaWAN augmente la taille des
+  paquets, ce qui se traduit par un airtime plus long qu’avec FLoRa.
+- L’implémentation des classes B/C introduit des fenêtres de réception
+  supplémentaires qui n’existent pas dans FLoRa.
+- Les algorithmes ADR ne prennent pas en compte exactement les mêmes
+  seuils, entraînant des évolutions de SF ou de puissance différentes.


### PR DESCRIPTION
## Summary
- add `docs/lorawan_features.md` comparing FLoRa and Python implementation
- link from README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884a6a9f7bc83318f4fd9c56c89398a