### PR TITLE
Add FLoRa path loss models

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,11 @@ où `th` est le seuil SNR par Spreading Factor ({7: -7.5, 8: -10, 9: -12.5,
 10: -15, 11: -17.5, 12: -20} dB). Ces équations sont activées en passant
 `phy_model="flora" ou "flora_full"` ou `use_flora_curves=True` au constructeur du `Channel`.
 
+Le paramètre ``flora_loss_model`` permet de choisir parmi plusieurs modèles
+d'atténuation : ``"lognorm"`` (par défaut), ``"oulu"`` correspondant à
+``LoRaPathLossOulu`` (B = 128.95 dB, n = 2.32, d0 = 1000 m) ou ``"hata"`` pour
+``LoRaHataOkumura`` (K1 = 127.5, K2 = 35.2).
+
 
 ## SF et puissance initiaux
 

--- a/simulateur_lora_sfrd/launcher/channel.py
+++ b/simulateur_lora_sfrd/launcher/channel.py
@@ -27,6 +27,8 @@ class Channel:
         "rural": (2.0, 2.0),
         # Parameters matching the FLoRa log-normal shadowing model
         "flora": (2.7, 3.57),
+        "flora_oulu": (2.32, 7.8),
+        "flora_hata": (2.08, 3.57),
         # Additional presets for denser or indoor environments
         "urban_dense": (3.0, 8.0),
         "indoor": (3.5, 7.0),
@@ -73,6 +75,7 @@ class Channel:
         variable_noise_std: float = 0.0,
         advanced_capture: bool = False,
         phy_model: str = "omnet",
+        flora_loss_model: str = "lognorm",
         system_loss_dB: float = 0.0,
         rssi_offset_dB: float = 0.0,
         snr_offset_dB: float = 0.0,
@@ -144,6 +147,8 @@ class Channel:
         :param variable_noise_std: Variation lente du bruit thermique en dB.
         :param advanced_capture: Active un mode de capture inspiré de FLoRa.
         :param phy_model: "omnet" (par défaut) pour utiliser le module OMNeT++.
+        :param flora_loss_model: Variante d'atténuation FLoRa à utiliser
+            ("lognorm", "oulu" ou "hata").
         :param system_loss_dB: Pertes fixes supplémentaires (par ex. pertes
             système) appliquées à la perte de parcours.
         :param rssi_offset_dB: Décalage appliqué au RSSI calculé (dB).
@@ -264,6 +269,7 @@ class Channel:
         self.variable_noise_std = variable_noise_std
         self.advanced_capture = advanced_capture
         self.phy_model = phy_model
+        self.flora_loss_model = flora_loss_model
         self.system_loss_dB = system_loss_dB
         self.rssi_offset_dB = rssi_offset_dB
         self.snr_offset_dB = snr_offset_dB
@@ -297,7 +303,7 @@ class Channel:
             self.advanced_capture = True
         elif self.phy_model in ("flora", "flora_full") or self.use_flora_curves:
             from .flora_phy import FloraPHY
-            self.flora_phy = FloraPHY(self)
+            self.flora_phy = FloraPHY(self, loss_model=self.flora_loss_model)
             self.omnet_phy = None
             self.advanced_capture = True
         else:

--- a/simulateur_lora_sfrd/launcher/simulator.py
+++ b/simulateur_lora_sfrd/launcher/simulator.py
@@ -102,6 +102,7 @@ class Simulator:
         seed: int | None = None,
         class_c_rx_interval: float = 1.0,
         phy_model: str = "",
+        flora_loss_model: str = "lognorm",
         terrain_map: str | list[list[float]] | None = None,
         path_map: str | list[list[float]] | None = None,
         dynamic_obstacles: str | list[dict] | None = None,
@@ -171,6 +172,8 @@ class Simulator:
             downlink pour les nœuds de classe C (s).
         :param phy_model: "omnet" ou "flora" pour activer un modèle physique
             inspiré de FLoRa.
+        :param flora_loss_model: Variante d'atténuation FLoRa ("lognorm",
+            "oulu" ou "hata").
         :param terrain_map: Carte de terrain utilisée pour la mobilité
             aléatoire (chemin JSON/texte ou matrice). Les valeurs négatives
             indiquent les obstacles et ralentissements éventuels.
@@ -242,6 +245,7 @@ class Simulator:
         self.flora_timing = flora_timing
         self.config_file = config_file
         self.phy_model = phy_model
+        self.flora_loss_model = flora_loss_model
         # Activation ou non de la mobilité des nœuds
         self.mobility_enabled = mobility
         if mobility_model is not None:
@@ -317,6 +321,7 @@ class Simulator:
                         detection_threshold_dBm=detection_threshold_dBm,
                         phy_model=ch_phy_model,
                         environment=env,
+                        flora_loss_model=flora_loss_model,
                     )
                 ]
             else:
@@ -346,6 +351,7 @@ class Simulator:
                                     if (flora_mode or phy_model.startswith("flora"))
                                     else None
                                 ),
+                                flora_loss_model=flora_loss_model,
                             )
                         )
             self.multichannel = MultiChannel(ch_list, method=channel_distribution)

--- a/tests/test_flora_rssi.py
+++ b/tests/test_flora_rssi.py
@@ -22,6 +22,26 @@ def flora_equations(tx_power: float, distance: float, sf: int, ch: Channel):
     return rssi, snr
 
 
+def oulu_equations(tx_power: float, distance: float, sf: int, ch: Channel):
+    """Return RSSI and SNR using the Oulu path loss model."""
+    loss = (
+        FloraPHY.OULU_B
+        + 10 * FloraPHY.OULU_N * math.log10(max(distance, 1.0) / FloraPHY.OULU_D0)
+        - FloraPHY.OULU_ANTENNA_GAIN
+    )
+    rssi = (
+        tx_power
+        + ch.tx_antenna_gain_dB
+        + ch.rx_antenna_gain_dB
+        - loss
+        - ch.cable_loss_dB
+        + ch.rssi_offset_dB
+    )
+    noise = ch.FLORA_SENSITIVITY[sf][int(ch.bandwidth)]
+    snr = rssi - noise + ch.snr_offset_dB + 10 * math.log10(2 ** sf)
+    return rssi, snr
+
+
 def test_channel_compute_rssi_matches_flora_equations():
     tx_power = 14.0
     distance = 100.0
@@ -29,6 +49,18 @@ def test_channel_compute_rssi_matches_flora_equations():
     ch = Channel(environment="flora", phy_model="flora_full")
     ch.shadowing_std = 0.0  # deterministic
     expected_rssi, expected_snr = flora_equations(tx_power, distance, sf, ch)
+    rssi, snr = ch.compute_rssi(tx_power, distance, sf=sf)
+    assert abs(rssi - expected_rssi) <= 0.01
+    assert abs(snr - expected_snr) <= 0.01
+
+
+def test_oulu_path_loss_model():
+    tx_power = 14.0
+    distance = 500.0
+    sf = 7
+    ch = Channel(phy_model="flora_full", flora_loss_model="oulu")
+    ch.shadowing_std = 0.0
+    expected_rssi, expected_snr = oulu_equations(tx_power, distance, sf, ch)
     rssi, snr = ch.compute_rssi(tx_power, distance, sf=sf)
     assert abs(rssi - expected_rssi) <= 0.01
     assert abs(snr - expected_snr) <= 0.01


### PR DESCRIPTION
## Summary
- support multiple FLoRa path loss models (lognorm, oulu, hata)
- expose `flora_loss_model` option in Channel and Simulator
- document new models and default values
- test LoRaPathLossOulu equations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884f1fff87c8331b0b26c2061a0152b