### PR TITLE
Amélioration du modèle analogique OMNeT++

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,12 @@ réception :
 - `pa_non_linearity_curve` : triplet de coefficients polynomiaux pour
   définir une non‑linéarité personnalisée.
 - `pa_distortion_std_dB` : variation aléatoire due aux imperfections du PA.
+- `pa_ramp_up_s` / `pa_ramp_down_s` : temps de montée et de descente du PA
+  influençant la puissance effective.
+- `impulsive_noise_prob` / `impulsive_noise_dB` : ajout de bruit impulsif selon
+  une probabilité donnée.
+- `adjacent_interference_dB` : pénalité appliquée aux brouilleurs situés sur un
+  canal adjacent.
 - `phase_noise_std_dB` : bruit de phase ajouté au SNR.
 - `oscillator_leakage_dB` / `oscillator_leakage_std_dB` : fuite
   d'oscillateur ajoutée au bruit.

--- a/tests/test_impulsive_noise.py
+++ b/tests/test_impulsive_noise.py
@@ -1,0 +1,15 @@
+import random
+from simulateur_lora_sfrd.launcher.channel import Channel
+
+
+def test_impulsive_noise_increases_floor():
+    random.seed(0)
+    base = Channel(noise_floor_std=0.0, variable_noise_std=0.0, fine_fading_std=0.0)
+    ch = Channel(
+        noise_floor_std=0.0,
+        variable_noise_std=0.0,
+        fine_fading_std=0.0,
+        impulsive_noise_prob=1.0,
+        impulsive_noise_dB=20.0,
+    )
+    assert ch.noise_floor_dBm() >= base.noise_floor_dBm() + 19.0

--- a/tests/test_pa_ramp.py
+++ b/tests/test_pa_ramp.py
@@ -1,0 +1,13 @@
+import random
+from simulateur_lora_sfrd.launcher.channel import Channel
+
+
+def test_pa_ramp_up_affects_rssi():
+    random.seed(0)
+    ch = Channel(phy_model="omnet", pa_ramp_up_s=1.0, shadowing_std=0.0, fast_fading_std=0.0)
+    ch.omnet_phy.start_tx()
+    ch.omnet_phy.update(0.5)
+    r1, _ = ch.compute_rssi(14.0, 10.0)
+    ch.omnet_phy.update(0.6)
+    r2, _ = ch.compute_rssi(14.0, 10.0)
+    assert r2 > r1


### PR DESCRIPTION
## Summary
- ajout de paramètres `pa_ramp_up_s`/`pa_ramp_down_s` pour modéliser la montée et la descente du PA
- prise en charge du bruit impulsif et des interférences de canaux adjacents
- adaptation des classes `OmnetPHY` et `AdvancedChannel`
- documentation mise à jour
- nouveaux tests unitaires

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884f98125488331a8ea236c50be6dfa