### PR TITLE
Add API wrapper modules

### DIFF
--- a/simulateur_lora_sfrd/__init__.py
+++ b/simulateur_lora_sfrd/__init__.py
@@ -1,1 +1,11 @@
-# Init for versioned package
+"""Top-level package for ``simulateur_lora_sfrd``.
+
+This module exposes convenience wrappers around core classes so they can be
+imported directly from the root package.
+"""
+
+from .loranode import Node
+from .gateway import Gateway
+from .network_server import NetworkServer
+
+__all__ = ["Node", "Gateway", "NetworkServer"]

--- a/simulateur_lora_sfrd/gateway.py
+++ b/simulateur_lora_sfrd/gateway.py
@@ -1,0 +1,5 @@
+"""Compatibility wrapper for :class:`~simulateur_lora_sfrd.launcher.gateway.Gateway`."""
+
+from .launcher.gateway import Gateway
+
+__all__ = ["Gateway"]

--- a/simulateur_lora_sfrd/loranode.py
+++ b/simulateur_lora_sfrd/loranode.py
@@ -1,0 +1,5 @@
+"""Compatibility wrapper for :class:`~simulateur_lora_sfrd.launcher.node.Node`."""
+
+from .launcher.node import Node
+
+__all__ = ["Node"]

--- a/simulateur_lora_sfrd/network_server.py
+++ b/simulateur_lora_sfrd/network_server.py
@@ -1,0 +1,5 @@
+"""Compatibility wrapper for :class:`~simulateur_lora_sfrd.launcher.server.NetworkServer`."""
+
+from .launcher.server import NetworkServer
+
+__all__ = ["NetworkServer"]


### PR DESCRIPTION
## Summary
- export Node, Gateway, and NetworkServer through new compatibility wrappers
- expose these wrappers at package level

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885622499a483318f2fef5336c68034