### PR TITLE
Add reference-based path loss model

### DIFF
--- a/simulateur_lora_sfrd/launcher/omnet_phy.py
+++ b/simulateur_lora_sfrd/launcher/omnet_phy.py
@@ -178,9 +178,11 @@ class OmnetPHY:
         """Return path loss in dB using the log distance model."""
         if distance <= 0:
             return 0.0
-        freq_mhz = self.channel.frequency_hz / 1e6
-        pl_d0 = 32.45 + 20 * math.log10(freq_mhz) - 60.0
-        loss = pl_d0 + 10 * self.channel.path_loss_exp * math.log10(max(distance, 1.0))
+        d = max(distance, 1.0)
+        ch = self.channel
+        loss = ch.path_loss_d0 + 10 * ch.path_loss_exp * math.log10(
+            d / ch.reference_distance
+        )
         return loss + self.channel.system_loss_dB
 
     def noise_floor(self) -> float:

--- a/tests/test_path_loss_presets.py
+++ b/tests/test_path_loss_presets.py
@@ -1,0 +1,20 @@
+import math
+from simulateur_lora_sfrd.launcher.propagation_models import LogDistanceShadowing
+from simulateur_lora_sfrd.launcher.channel import Channel
+
+
+def test_logdistance_urban_preset():
+    model = LogDistanceShadowing(environment="urban")
+    model.shadowing_std = 0.0
+    loss = model.path_loss(80.0)
+    expected = 127.41 + 10 * 2.08 * math.log10(80.0 / 40.0)
+    assert math.isclose(loss, expected, rel_tol=1e-6)
+
+
+def test_channel_preset_matches_logdistance():
+    ch = Channel(environment="urban")
+    ch.shadowing_std = 0.0
+    ch.fast_fading_std = 0.0
+    ld = LogDistanceShadowing(environment="urban")
+    ld.shadowing_std = 0.0
+    assert math.isclose(ch.path_loss(80.0), ld.path_loss(80.0), rel_tol=1e-6)


### PR DESCRIPTION
## Summary
- extend `LogDistanceShadowing` with `path_loss_d0` and `reference_distance`
- update loss computation to use reference distance
- provide new environment tuples
- adapt `Channel` and `OmnetPHY` to handle the new parameters
- add regression tests for preset path‑loss values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688562503b54833184a819b1041e9797