### PR TITLE
Fix TX energy accounting and test

### DIFF
--- a/simulateur_lora_sfrd/launcher/simulator.py
+++ b/simulateur_lora_sfrd/launcher/simulator.py
@@ -674,7 +674,7 @@ class Simulator:
             if not node.alive:
                 return True
             node.state = "tx"
-            node.last_state_time = time
+            node.last_state_time = end_time
             # Marquer le nœud comme en cours de transmission
             node.in_transmission = True
             node.current_end_time = end_time

--- a/tests/test_energy_accounting.py
+++ b/tests/test_energy_accounting.py
@@ -1,0 +1,24 @@
+import pytest
+from simulateur_lora_sfrd.launcher.simulator import Simulator
+
+
+def test_tx_energy_accounted_once():
+    sim = Simulator(
+        num_nodes=1,
+        num_gateways=1,
+        transmission_mode="Periodic",
+        packet_interval=1.0,
+        packets_to_send=1,
+        mobility=False,
+        fixed_sf=7,
+        fixed_tx_power=14.0,
+        seed=0,
+    )
+    sim.run()
+    node = sim.nodes[0]
+    expected = (
+        node.profile.get_tx_current(node.tx_power)
+        * node.profile.voltage_v
+        * node.channel.airtime(node.sf, payload_size=sim.payload_size_bytes)
+    )
+    assert node.energy_tx == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- ensure simulator accounts TX energy only once by updating `last_state_time` to `end_time`
- add regression test checking transmission energy

## Testing
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688562e4e6888331be25c2280844c7a9