### PR TITLE
Add per-node airtime and energy metrics

### DIFF
--- a/simulateur_lora_sfrd/launcher/node.py
+++ b/simulateur_lora_sfrd/launcher/node.py
@@ -211,6 +211,7 @@ class Node:
         self.in_transmission: bool = False
         self.current_end_time: float | None = None
         self.last_airtime: float = 0.0
+        self.total_airtime: float = 0.0
         self.last_rssi: float | None = None
         self.last_snr: float | None = None
         self.downlink_pending: int = 0
@@ -301,6 +302,7 @@ class Node:
             "energy_sleep_J": self.energy_sleep,
             "energy_processing_J": self.energy_processing,
             "energy_consumed_J": self.energy_consumed,
+            "airtime_s": self.total_airtime,
             "battery_capacity_J": self.battery_capacity_j,
             "battery_remaining_J": self.battery_remaining_j,
             "packets_sent": self.packets_sent,

--- a/simulateur_lora_sfrd/launcher/simulator.py
+++ b/simulateur_lora_sfrd/launcher/simulator.py
@@ -659,6 +659,7 @@ class Simulator:
             # Durée de la transmission
             duration = node.channel.airtime(sf, payload_size=self.payload_size_bytes)
             node.last_airtime = duration
+            node.total_airtime += duration
             end_time = time + duration
             if self.duty_cycle_manager and not self.pure_poisson_mode:
                 self.duty_cycle_manager.update_after_tx(node_id, time, duration)
@@ -1232,6 +1233,9 @@ class Simulator:
             for ct in class_types
         }
 
+        energy_by_node = {n.id: n.energy_consumed for n in self.nodes}
+        airtime_by_node = {n.id: n.total_airtime for n in self.nodes}
+
         interval_sum = 0.0
         interval_count = 0
         for n in self.nodes:
@@ -1267,6 +1271,8 @@ class Simulator:
             "pdr_by_sf": pdr_by_sf,
             "pdr_by_gateway": pdr_by_gateway,
             "pdr_by_class": pdr_by_class,
+            "energy_by_node": energy_by_node,
+            "airtime_by_node": airtime_by_node,
             **{f"energy_class_{ct}_J": energy_by_class[ct] for ct in energy_by_class},
             "retransmissions": self.retransmissions,
         }

--- a/tests/test_airtime_energy.py
+++ b/tests/test_airtime_energy.py
@@ -1,0 +1,19 @@
+from simulateur_lora_sfrd.launcher.simulator import Simulator
+
+
+def test_energy_and_airtime_metrics():
+    sim = Simulator(
+        num_nodes=1,
+        num_gateways=1,
+        transmission_mode="Periodic",
+        packet_interval=1.0,
+        packets_to_send=2,
+        mobility=False,
+        seed=0,
+    )
+    sim.run()
+    metrics = sim.get_metrics()
+    node = sim.nodes[0]
+    nid = node.id
+    assert abs(metrics["energy_by_node"][nid] - node.energy_consumed) < 1e-9
+    assert abs(metrics["airtime_by_node"][nid] - node.total_airtime) < 1e-9


### PR DESCRIPTION
## Summary
- track cumulative airtime for each node
- expose `energy_by_node` and `airtime_by_node` in simulator metrics
- include airtime in node export data
- test that per-node metrics are reported correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68856344f9a08331b08b3524a825418b