### PR TITLE
Add plotting example scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,13 @@ run :
 python examples/analyse_runs.py résultats.csv
 ```
 
+Deux autres scripts facilitent la visualisation des métriques exportées :
+
+```bash
+python examples/plot_sf_distribution.py metrics1.csv  # histogramme des SF
+python examples/plot_energy.py metrics1.csv           # énergie totale ou par nœud
+```
+
 ## Nettoyage des résultats
 
 Le script `launcher/clean_results.py` supprime les doublons et les valeurs

--- a/examples/plot_energy.py
+++ b/examples/plot_energy.py
@@ -1,0 +1,56 @@
+import sys
+import pandas as pd
+import matplotlib.pyplot as plt
+
+
+def load_data(files: list[str]) -> pd.DataFrame:
+    """Load and concatenate CSV files."""
+    frames = [pd.read_csv(f) for f in files]
+    return pd.concat(frames, ignore_index=True)
+
+
+def plot_total_energy(df: pd.DataFrame) -> None:
+    col = None
+    for c in ("energy_J", "energy"):
+        if c in df.columns:
+            col = c
+            break
+    if col is None:
+        print("Aucune colonne d'énergie trouvée")
+        return
+    df[col].plot(marker="o")
+    plt.xlabel("Simulation")
+    plt.ylabel("Énergie totale (J)")
+    plt.title("Énergie consommée par simulation")
+    plt.grid(True)
+    plt.savefig("energy_total.png")
+    print("Graphique sauvegardé dans energy_total.png")
+
+
+def plot_energy_by_node(df: pd.DataFrame) -> None:
+    if "node_id" not in df.columns or "energy_consumed_J_node" not in df.columns:
+        print("Colonnes 'node_id' ou 'energy_consumed_J_node' manquantes")
+        return
+    grouped = df.groupby("node_id")["energy_consumed_J_node"].sum()
+    grouped.plot(kind="bar")
+    plt.xlabel("ID nœud")
+    plt.ylabel("Énergie consommée (J)")
+    plt.title("Énergie consommée par nœud")
+    plt.grid(axis="y")
+    plt.savefig("energy_by_node.png")
+    print("Graphique sauvegardé dans energy_by_node.png")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(
+            "Usage: python plot_energy.py fichier1.csv [...]\n"
+            "Si le CSV contient les colonnes node_id et energy_consumed_J_node, "
+            "un graphique par nœud sera généré."
+        )
+    else:
+        df = load_data(sys.argv[1:])
+        if {"node_id", "energy_consumed_J_node"}.issubset(df.columns):
+            plot_energy_by_node(df)
+        else:
+            plot_total_energy(df)

--- a/examples/plot_sf_distribution.py
+++ b/examples/plot_sf_distribution.py
@@ -1,0 +1,45 @@
+import sys
+import pandas as pd
+import matplotlib.pyplot as plt
+
+
+def load_data(files: list[str]) -> pd.DataFrame:
+    """Load and concatenate metrics CSV files."""
+    frames = [pd.read_csv(f) for f in files]
+    return pd.concat(frames, ignore_index=True)
+
+
+def get_sf_columns(df: pd.DataFrame) -> tuple[list[str], list[int]]:
+    """Return columns storing SF distribution and their numeric value."""
+    # Columns created by pandas.json_normalize: "sf_distribution.7"
+    cols = [c for c in df.columns if c.startswith("sf_distribution.")]
+    if cols:
+        sfs = [int(c.split(".")[1]) for c in cols]
+        return cols, sfs
+    # Fallback to flat columns: "sf7"
+    cols = [c for c in df.columns if c.startswith("sf") and c[2:].isdigit()]
+    sfs = [int(c[2:]) for c in cols]
+    return cols, sfs
+
+
+def plot_distribution(df: pd.DataFrame) -> None:
+    cols, sfs = get_sf_columns(df)
+    if not cols:
+        print("Aucune colonne de distribution SF trouvée")
+        return
+    counts = df[cols].sum()
+    plt.bar([f"SF{sf}" for sf in sfs], counts)
+    plt.xlabel("Facteur d'étalement")
+    plt.ylabel("Nombre")
+    plt.title("Répartition des SF")
+    plt.grid(axis="y")
+    plt.savefig("sf_distribution.png")
+    print("Graphique sauvegardé dans sf_distribution.png")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python plot_sf_distribution.py metrics1.csv [...]")
+    else:
+        df = load_data(sys.argv[1:])
+        plot_distribution(df)


### PR DESCRIPTION
## Summary
- add `plot_sf_distribution.py` to graph SF histograms
- add `plot_energy.py` to plot total or per-node energy usage
- reference the new scripts in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688563497adc833198be9560223efe37