### PR TITLE
Expose top-level Node, Gateway and NetworkServer

### DIFF
--- a/simulateur_lora_sfrd/__init__.py
+++ b/simulateur_lora_sfrd/__init__.py
@@ -3,5 +3,15 @@
 from .mac import LoRaMAC
 from .phy import LoRaPHY
 from .application import Application
+from .loranode import Node
+from .gateway import Gateway
+from .network_server import NetworkServer
 
-__all__ = ["LoRaMAC", "LoRaPHY", "Application"]
+__all__ = [
+    "LoRaMAC",
+    "LoRaPHY",
+    "Application",
+    "Node",
+    "Gateway",
+    "NetworkServer",
+]

--- a/simulateur_lora_sfrd/gateway.py
+++ b/simulateur_lora_sfrd/gateway.py
@@ -1,0 +1,5 @@
+"""Wrapper module exposing :class:`Gateway`."""
+
+from .launcher.gateway import Gateway
+
+__all__ = ["Gateway"]

--- a/simulateur_lora_sfrd/loranode.py
+++ b/simulateur_lora_sfrd/loranode.py
@@ -1,0 +1,5 @@
+"""Wrapper module exposing :class:`Node`."""
+
+from .launcher.node import Node
+
+__all__ = ["Node"]

--- a/simulateur_lora_sfrd/network_server.py
+++ b/simulateur_lora_sfrd/network_server.py
@@ -1,0 +1,5 @@
+"""Wrapper module exposing :class:`NetworkServer`."""
+
+from .launcher.server import NetworkServer
+
+__all__ = ["NetworkServer"]


### PR DESCRIPTION
## Summary
- add wrapper modules around Node, Gateway and NetworkServer
- re-export the wrappers from package `__init__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688569a62c548331b54b7f7e80fd9f12