### PR TITLE
Fix Oulu shadowing preset

### DIFF
--- a/simulateur_lora_sfrd/launcher/channel.py
+++ b/simulateur_lora_sfrd/launcher/channel.py
@@ -27,7 +27,7 @@ class Channel:
         "rural": (2.0, 2.0, 113.0, 1.0),
         # Parameters matching the FLoRa log-normal shadowing model
         "flora": (2.7, 3.57, 127.41, 40.0),
-        "flora_oulu": (2.32, 7.8, 128.95, 1000.0),
+        "flora_oulu": (2.32, 7.08, 128.95, 1000.0),
         "flora_hata": (2.08, 3.57, 127.5, 40.0),
         # Additional presets for denser or indoor environments
         "urban_dense": (3.0, 8.0, 127.41, 40.0),


### PR DESCRIPTION
## Summary
- correct the `flora_oulu` environment constant in `Channel.ENV_PRESETS`
- run test suite

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68856a21ef0483318b3a46d34f6769ee