### PR TITLE
Fix cross-SF collision detection

### DIFF
--- a/simulateur_lora_sfrd/launcher/gateway.py
+++ b/simulateur_lora_sfrd/launcher/gateway.py
@@ -83,9 +83,17 @@ class Gateway:
         """
         key = (sf, frequency)
         symbol_duration = (2 ** sf) / bandwidth
-        concurrent_transmissions = [
-            t for t in self.active_map.get(key, []) if t['end_time'] > current_time
-        ]
+        # Gather all active transmissions that share the same frequency. When
+        # ``orthogonal_sf`` is ``True`` we only consider the same SF. Otherwise
+        # we must look across all SFs on this frequency.
+        if orthogonal_sf:
+            candidates = self.active_map.get(key, [])
+        else:
+            candidates = []
+            for (sf_k, freq_k), txs in self.active_map.items():
+                if freq_k == frequency:
+                    candidates.extend(txs)
+        concurrent_transmissions = [t for t in candidates if t['end_time'] > current_time]
 
         # Filtrer les transmissions dont le chevauchement est significatif
         interfering_transmissions = []
@@ -215,8 +223,9 @@ class Gateway:
             # Retirer toutes les transmissions concurrentes actives qui sont perdantes
             for t in interfering_transmissions:
                 if t['lost_flag']:
+                    t_key = (t['sf'], t['frequency'])
                     try:
-                        self.active_map[key].remove(t)
+                        self.active_map[t_key].remove(t)
                         self.active_by_event.pop(t['event_id'], None)
                     except (ValueError, KeyError):
                         pass
@@ -238,8 +247,9 @@ class Gateway:
                 t['lost_flag'] = True
             # Retirer tous les paquets concurrents actifs (ils ne seront pas décodés finalement)
             for t in interfering_transmissions:
+                t_key = (t['sf'], t['frequency'])
                 try:
-                    self.active_map[key].remove(t)
+                    self.active_map[t_key].remove(t)
                     self.active_by_event.pop(t['event_id'], None)
                 except (ValueError, KeyError):
                     pass

--- a/tests/test_gateway_capture.py
+++ b/tests/test_gateway_capture.py
@@ -61,3 +61,32 @@ def test_strong_signal_arrives_late():
     gw.end_reception(2, server, 2)
 
     assert server.packets_received == 0
+
+
+def test_cross_sf_collision():
+    gw = Gateway(0, 0, 0)
+    server = NetworkServer()
+    server.gateways = [gw]
+
+    # Two packets on the same frequency with different SF collide
+    gw.start_reception(1, 1, 7, -60, 1.0, 6.0, 0.0, 868e6, orthogonal_sf=False)
+    gw.start_reception(2, 2, 9, -60, 1.0, 6.0, 0.0, 868e6, orthogonal_sf=False)
+    gw.end_reception(1, server, 1)
+    gw.end_reception(2, server, 2)
+
+    assert server.packets_received == 0
+
+
+def test_cross_sf_capture_after_delay():
+    gw = Gateway(0, 0, 0)
+    server = NetworkServer()
+    server.gateways = [gw]
+
+    # Strong signal starts first and should capture the weaker one
+    gw.start_reception(1, 1, 7, -50, 1.0, 6.0, 0.0, 868e6, orthogonal_sf=False)
+    # Weaker packet with higher SF starts after more than 5 of its symbols
+    gw.start_reception(2, 2, 9, -60, 1.0, 6.0, 0.03, 868e6, orthogonal_sf=False)
+    gw.end_reception(1, server, 1)
+    gw.end_reception(2, server, 2)
+
+    assert server.packets_received == 1


### PR DESCRIPTION
## Summary
- consider all SFs when detecting collisions if `orthogonal_sf` is False
- remove losing transmissions from their own buckets
- test cross-SF collision scenarios

## Testing
- `pytest tests/test_gateway_capture.py::test_cross_sf_collision -q`
- `pytest tests/test_gateway_capture.py::test_cross_sf_capture_after_delay -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68856accd3188331ba9b26d84535334a