### PR TITLE
Add metrics plotting examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,18 @@ run :
 python examples/analyse_runs.py résultats.csv
 ```
 
+Deux autres utilitaires exploitent les fichiers `metrics_*.csv` exportés par le
+tableau de bord :
+
+```bash
+python examples/plot_sf_distribution.py metrics1.csv metrics2.csv
+python examples/plot_energy.py metrics.csv            # énergie totale
+python examples/plot_energy.py --per-node metrics.csv # par nœud
+```
+
+`plot_sf_distribution.py` génère `sf_distribution.png` alors que
+`plot_energy.py` crée `energy_total.png` ou `energy_per_node.png`.
+
 ## Calcul de l'airtime
 
 La durée d'un paquet LoRa est obtenue à partir de la formule théorique :

--- a/examples/plot_energy.py
+++ b/examples/plot_energy.py
@@ -1,0 +1,56 @@
+"""Trace la consommation d'\u00e9nergie totale ou par n\u0153ud depuis des CSV."""
+import sys
+import argparse
+import pandas as pd
+import matplotlib.pyplot as plt
+
+
+def main(files: list[str], per_node: bool) -> None:
+    df = pd.concat([pd.read_csv(f) for f in files], ignore_index=True)
+    if per_node:
+        cols = [c for c in df.columns if c.startswith("energy_by_node.")]
+        if not cols:
+            print("Aucune colonne de consommation par n\u0153ud trouv\u00e9e.")
+            return
+        energy = {int(c.split(".")[1]): df[c].mean() for c in cols}
+        nodes = sorted(energy)
+        values = [energy[n] for n in nodes]
+        plt.bar(nodes, values)
+        plt.xlabel("N\u0153ud")
+        plt.ylabel("\u00c9nergie consomm\u00e9e (J)")
+        plt.grid(True)
+        plt.savefig("energy_per_node.png")
+        print("Graphique sauvegard\u00e9 dans energy_per_node.png")
+    else:
+        col = "energy_J" if "energy_J" in df.columns else "energy"
+        if col not in df.columns:
+            print("Aucune colonne energy_J ou energy trouv\u00e9e.")
+            return
+        if "nodes" in df.columns:
+            series = df.groupby("nodes")[col].mean()
+            series.plot(marker="o")
+            plt.xlabel("Nombre de n\u0153uds")
+        else:
+            series = df[col]
+            series.plot(marker="o")
+            plt.xlabel("Ex\u00e9cution")
+        plt.ylabel("\u00c9nergie consomm\u00e9e (J)")
+        plt.grid(True)
+        plt.savefig("energy_total.png")
+        print("Graphique sauvegard\u00e9 dans energy_total.png")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Trace l'\u00e9nergie consomm\u00e9e")
+    parser.add_argument("files", nargs="+", help="Fichiers metrics CSV")
+    parser.add_argument(
+        "--per-node",
+        action="store_true",
+        help="Trace la consommation pour chaque n\u0153ud",
+    )
+    return parser.parse_args(argv)
+
+
+if __name__ == "__main__":
+    args = parse_args(sys.argv[1:])
+    main(args.files, args.per_node)

--- a/examples/plot_sf_distribution.py
+++ b/examples/plot_sf_distribution.py
@@ -1,0 +1,34 @@
+"""Trace la distribution des Spreading Factors depuis des fichiers CSV."""
+import sys
+import pandas as pd
+import matplotlib.pyplot as plt
+
+
+def main(files: list[str]) -> None:
+    df = pd.concat([pd.read_csv(f) for f in files], ignore_index=True)
+    sf_cols = [c for c in df.columns if c.startswith("sf_distribution.")]
+    if sf_cols:
+        sf_counts = {int(c.split(".")[1]): int(df[c].sum()) for c in sf_cols}
+    else:
+        sf_cols = [c for c in df.columns if c.startswith("sf")]
+        sf_counts = {int(c[2:]): int(df[c].sum()) for c in sf_cols}
+    if not sf_counts:
+        print("Aucune colonne SF trouv\u00e9e dans les fichiers fournis.")
+        return
+    sfs = sorted(sf_counts)
+    counts = [sf_counts[sf] for sf in sfs]
+    for sf, count in zip(sfs, counts):
+        print(f"SF{sf}: {count}")
+    plt.bar(sfs, counts)
+    plt.xlabel("Spreading Factor")
+    plt.ylabel("Paquets")
+    plt.grid(True)
+    plt.savefig("sf_distribution.png")
+    print("Graphique sauvegard\u00e9 dans sf_distribution.png")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python plot_sf_distribution.py metrics1.csv [...]")
+    else:
+        main(sys.argv[1:])


### PR DESCRIPTION
## Summary
- add `plot_sf_distribution.py` to visualize spreading factor histograms
- add `plot_energy.py` for total or per-node energy plots
- document new scripts in README under analysis section

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68856c891c648331b8a0dedf582f1725