### PR TITLE
Add coefficient of variation test for exponential intervals

### DIFF
--- a/tests/test_interval_distribution.py
+++ b/tests/test_interval_distribution.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+import math
 
 from traffic.exponential import sample_interval
 
@@ -21,3 +22,23 @@ def test_interval_distribution_mean(seed: int) -> None:
         total += sample_interval(mean_interval, rng)
     average = total / count
     assert abs(average - mean_interval) / mean_interval < 0.01
+
+
+@pytest.mark.parametrize("seed", range(10))
+def test_interval_distribution_cv(seed: int) -> None:
+    """``sample_interval`` should have a coefficient of variation of 1."""
+
+    mean_interval = 10.0
+    count = 1_000_000
+    rng = np.random.Generator(np.random.MT19937(seed))
+    total = 0.0
+    sumsq = 0.0
+    for _ in range(count):
+        x = sample_interval(mean_interval, rng)
+        total += x
+        sumsq += x * x
+    mean = total / count
+    variance = sumsq / count - mean * mean
+    std = math.sqrt(variance)
+    cv = std / mean
+    assert abs(cv - 1.0) < 0.02


### PR DESCRIPTION
## Summary
- extend interval distribution tests
- add `test_interval_distribution_cv` verifying coefficient of variation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885749af32c8331b281550dd8f80e63