### PR TITLE
Fix example and pytest marker

### DIFF
--- a/examples/run_basic.py
+++ b/examples/run_basic.py
@@ -22,7 +22,7 @@ if __name__ == "__main__":
 
     sim = Simulator(
         num_nodes=args.nodes,
-        packet_interval=10,
+        packet_interval=10.0,
         transmission_mode="Random",
         adr_method="avg",
         dump_intervals=args.dump_intervals,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 testpaths = tests
+markers =
+    slow: tests that take longer to run


### PR DESCRIPTION
## Summary
- fix `examples/run_basic.py` by using a float packet interval
- register custom `slow` marker in pytest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885766211088331962a946d8ac30c67