### PR TITLE
Fix LoRaPHY random handling

### DIFF
--- a/simulateur_lora_sfrd/phy.py
+++ b/simulateur_lora_sfrd/phy.py
@@ -21,7 +21,13 @@ class LoRaPHY:
         return self.channel.airtime(self.node.sf, payload_size)
 
     # ------------------------------------------------------------------
-    def transmit(self, dest: Node, payload_size: int) -> tuple[float, float, float, bool]:
+    def transmit(
+        self,
+        dest: Node,
+        payload_size: int,
+        *,
+        rng: random.Random | None = None,
+    ) -> tuple[float, float, float, bool]:
         """Simulate a transmission to ``dest``.
 
         Parameters
@@ -46,7 +52,8 @@ class LoRaPHY:
             sync_offset_s=self.node.current_sync_offset,
         )
         per = self.channel.packet_error_rate(snr, self.node.sf, payload_bytes=payload_size)
-        success = random.random() > per
+        rand = rng.random() if rng is not None else random.random()
+        success = rand > per
         return rssi, snr, self.airtime(payload_size), success
 
 

--- a/tests/test_loraphy_rng.py
+++ b/tests/test_loraphy_rng.py
@@ -1,0 +1,20 @@
+import random
+from simulateur_lora_sfrd.phy import LoRaPHY
+from simulateur_lora_sfrd.loranode import Node
+from simulateur_lora_sfrd.launcher.channel import Channel
+
+
+def test_loraphy_transmit_deterministic():
+    ch1 = Channel(shadowing_std=0.0, fast_fading_std=0.0, noise_floor_std=0.0)
+    ch2 = Channel(shadowing_std=0.0, fast_fading_std=0.0, noise_floor_std=0.0)
+    n1 = Node(0, 0, 0, 7, 14, channel=ch1)
+    n2 = Node(1, 0, 0, 7, 14, channel=ch2)
+
+    phy = LoRaPHY(n1)
+    rng1 = random.Random(123)
+    random.seed(0)
+    res1 = phy.transmit(n2, 20, rng=rng1)
+    rng2 = random.Random(123)
+    random.seed(0)
+    res2 = phy.transmit(n2, 20, rng=rng2)
+    assert res1 == res2


### PR DESCRIPTION
## Summary
- add an optional `rng` parameter to `LoRaPHY.transmit`
- use the provided RNG for packet success calculation
- test deterministic behaviour when a RNG is supplied

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885767e20648331ad09f02530016604