### PR TITLE
Expose RNG in channel and mobility modules

### DIFF
--- a/simulateur_lora_sfrd/launcher/gauss_markov.py
+++ b/simulateur_lora_sfrd/launcher/gauss_markov.py
@@ -1,5 +1,5 @@
 import math
-import random
+import numpy as np
 
 
 class GaussMarkov:
@@ -14,14 +14,19 @@ class GaussMarkov:
         speed_std: float = 0.2,
         direction_std: float = 0.2,
         step: float = 1.0,
+        rng: np.random.Generator | None = None,
     ) -> None:
         self.area_size = float(area_size)
         self.mean_speed = float(mean_speed)
-        self.mean_direction = mean_direction if mean_direction is not None else random.random() * 2 * math.pi
+        init_rng = rng or np.random.Generator(np.random.MT19937())
+        self.mean_direction = (
+            mean_direction if mean_direction is not None else init_rng.random() * 2 * math.pi
+        )
         self.alpha = float(alpha)
         self.speed_std = float(speed_std)
         self.direction_std = float(direction_std)
         self.step = float(step)
+        self.rng = init_rng
 
     # ------------------------------------------------------------------
     def assign(self, node) -> None:
@@ -36,12 +41,12 @@ class GaussMarkov:
         node.speed = (
             self.alpha * node.speed
             + (1 - self.alpha) * self.mean_speed
-            + math.sqrt(1 - self.alpha ** 2) * random.gauss(0.0, self.speed_std)
+            + math.sqrt(1 - self.alpha ** 2) * self.rng.normal(0.0, self.speed_std)
         )
         node.direction = (
             self.alpha * node.direction
             + (1 - self.alpha) * self.mean_direction
-            + math.sqrt(1 - self.alpha ** 2) * random.gauss(0.0, self.direction_std)
+            + math.sqrt(1 - self.alpha ** 2) * self.rng.normal(0.0, self.direction_std)
         )
         node.vx = node.speed * math.cos(node.direction)
         node.vy = node.speed * math.sin(node.direction)

--- a/simulateur_lora_sfrd/launcher/mobility.py
+++ b/simulateur_lora_sfrd/launcher/mobility.py
@@ -1,5 +1,6 @@
 import math
-import random
+import numpy as np
+import numpy as np
 
 
 class RandomWaypoint:
@@ -26,6 +27,7 @@ class RandomWaypoint:
         step: float = 1.0,
         slope_scale: float = 0.1,
         dynamic_obstacles: list[dict[str, float]] | None = None,
+        rng: np.random.Generator | None = None,
     ) -> None:
         """
         Initialise le modèle de mobilité.
@@ -61,6 +63,7 @@ class RandomWaypoint:
             self.e_rows = 0
             self.e_cols = 0
         self.dynamic_obstacles = [dict(o) for o in (dynamic_obstacles or [])]
+        self.rng = rng or np.random.Generator(np.random.MT19937())
         self._last_obs_update = 0.0
 
     # ------------------------------------------------------------------
@@ -120,8 +123,8 @@ class RandomWaypoint:
         Initialise également son dernier temps de déplacement.
         """
         # Tirer un angle de direction uniforme dans [0, 2π) et une vitesse uniforme dans [min_speed, max_speed].
-        angle = random.random() * 2 * math.pi
-        speed = random.uniform(self.min_speed, self.max_speed)
+        angle = self.rng.random() * 2 * math.pi
+        speed = self.min_speed + (self.max_speed - self.min_speed) * self.rng.random()
         # Définir les composantes de vitesse selon la direction.
         node.vx = speed * math.cos(angle)
         node.vy = speed * math.sin(angle)

--- a/simulateur_lora_sfrd/launcher/smooth_mobility.py
+++ b/simulateur_lora_sfrd/launcher/smooth_mobility.py
@@ -1,5 +1,5 @@
 import math
-import random
+import numpy as np
 
 
 def bezier_point(p0, p1, p2, p3, t):
@@ -22,15 +22,26 @@ def bezier_point(p0, p1, p2, p3, t):
 class SmoothMobility:
     """Smooth node mobility based on cubic Bezier interpolation."""
 
-    def __init__(self, area_size: float, min_speed: float = 2.0, max_speed: float = 10.0, step: float = 1.0):
+    def __init__(
+        self,
+        area_size: float,
+        min_speed: float = 2.0,
+        max_speed: float = 10.0,
+        step: float = 1.0,
+        *,
+        rng: np.random.Generator | None = None,
+    ):
         self.area_size = area_size
         self.min_speed = min_speed
         self.max_speed = max_speed
         self.step = step
+        self.rng = rng or np.random.Generator(np.random.MT19937())
 
     def assign(self, node):
         """Initialize path and speed for a node."""
-        node.speed = float(random.uniform(self.min_speed, self.max_speed))
+        node.speed = float(
+            self.min_speed + (self.max_speed - self.min_speed) * self.rng.random()
+        )
         node.path = self._generate_path(node.x, node.y)
         node.path_progress = 0.0
         node.path_duration = self._approx_length(node.path) / node.speed
@@ -39,12 +50,12 @@ class SmoothMobility:
     def _generate_path(self, x: float, y: float):
         start = (float(x), float(y))
         dest = (
-            random.random() * self.area_size,
-            random.random() * self.area_size,
+            self.rng.random() * self.area_size,
+            self.rng.random() * self.area_size,
         )
         offset = (
-            (random.random() - 0.5) * (self.area_size * 0.1),
-            (random.random() - 0.5) * (self.area_size * 0.1),
+            (self.rng.random() - 0.5) * (self.area_size * 0.1),
+            (self.rng.random() - 0.5) * (self.area_size * 0.1),
         )
         cp1 = (
             start[0] + (dest[0] - start[0]) / 3 + offset[0],

--- a/simulateur_lora_sfrd/launcher/terrain_mobility.py
+++ b/simulateur_lora_sfrd/launcher/terrain_mobility.py
@@ -1,5 +1,5 @@
 import math
-import random
+import numpy as np
 from typing import List, Tuple
 
 
@@ -16,6 +16,7 @@ class TerrainMapMobility:
         elevation: List[List[float]] | None = None,
         obstacle_height_map: List[List[float]] | None = None,
         max_height: float = 0.0,
+        rng: np.random.Generator | None = None,
     ) -> None:
         self.area_size = float(area_size)
         self.terrain = terrain
@@ -36,6 +37,7 @@ class TerrainMapMobility:
             self.h_cols = len(obstacle_height_map[0]) if self.h_rows else 0
         else:
             self.h_rows = self.h_cols = 0
+        self.rng = rng or np.random.Generator(np.random.MT19937())
 
     # ------------------------------------------------------------------
     def _speed_factor_cell(self, cx: int, cy: int) -> float:
@@ -113,8 +115,8 @@ class TerrainMapMobility:
 
     def _random_free_cell(self) -> Tuple[int, int]:
         while True:
-            cx = random.randrange(self.cols)
-            cy = random.randrange(self.rows)
+            cx = int(self.rng.integers(self.cols))
+            cy = int(self.rng.integers(self.rows))
             if self.terrain[cy][cx] > 0 and self._height_cell(cx, cy) <= self.max_height:
                 return cx, cy
 
@@ -129,7 +131,9 @@ class TerrainMapMobility:
 
     # ------------------------------------------------------------------
     def assign(self, node) -> None:
-        node.speed = float(random.uniform(self.min_speed, self.max_speed))
+        node.speed = float(
+            self.min_speed + (self.max_speed - self.min_speed) * self.rng.random()
+        )
         node.path = self._new_path(node.x, node.y)
         node.path_index = 0
         node.last_move_time = 0.0

--- a/simulateur_lora_sfrd/launcher/waypoint_planner.py
+++ b/simulateur_lora_sfrd/launcher/waypoint_planner.py
@@ -1,6 +1,6 @@
 # Path planner using A* over a terrain map with optional elevation and 3D obstacles.
 import math
-import random
+import numpy as np
 from typing import List, Tuple
 
 
@@ -16,6 +16,7 @@ class WaypointPlanner3D:
         obstacle_height_map: List[List[float]] | None = None,
         max_height: float = 0.0,
         slope_scale: float = 0.1,
+        rng: np.random.Generator | None = None,
     ) -> None:
         self.area_size = float(area_size)
         self.terrain = terrain
@@ -35,6 +36,7 @@ class WaypointPlanner3D:
         else:
             self.h_rows = self.h_cols = 0
         self.slope_scale = slope_scale
+        self.rng = rng or np.random.Generator(np.random.MT19937())
 
     # --------------------------------------------------------------
     def _terrain_factor_cell(self, cx: int, cy: int) -> float | None:
@@ -132,8 +134,8 @@ class WaypointPlanner3D:
 
     def random_free_point(self) -> Tuple[float, float]:
         while True:
-            cx = random.randrange(self.cols)
-            cy = random.randrange(self.rows)
+            cx = int(self.rng.integers(self.cols))
+            cy = int(self.rng.integers(self.rows))
             if self._terrain_factor_cell(cx, cy) is not None:
                 if self._height_cell(cx, cy) <= self.max_height:
                     return self._cell_to_coord((cx, cy))

--- a/simulateur_lora_sfrd/phy.py
+++ b/simulateur_lora_sfrd/phy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import random
+import numpy as np
 
 from .loranode import Node
 
@@ -26,7 +27,7 @@ class LoRaPHY:
         dest: Node,
         payload_size: int,
         *,
-        rng: random.Random | None = None,
+        rng: np.random.Generator | None = None,
     ) -> tuple[float, float, float, bool]:
         """Simulate a transmission to ``dest``.
 

--- a/tests/test_impulsive_noise.py
+++ b/tests/test_impulsive_noise.py
@@ -1,15 +1,21 @@
-import random
 from simulateur_lora_sfrd.launcher.channel import Channel
+from traffic.rng_manager import RngManager
 
 
 def test_impulsive_noise_increases_floor():
-    random.seed(0)
-    base = Channel(noise_floor_std=0.0, variable_noise_std=0.0, fine_fading_std=0.0)
+    mgr = RngManager(0)
+    base = Channel(
+        noise_floor_std=0.0,
+        variable_noise_std=0.0,
+        fine_fading_std=0.0,
+        rng=mgr.get_stream("base", 0),
+    )
     ch = Channel(
         noise_floor_std=0.0,
         variable_noise_std=0.0,
         fine_fading_std=0.0,
         impulsive_noise_prob=1.0,
         impulsive_noise_dB=20.0,
+        rng=mgr.get_stream("ch", 0),
     )
     assert ch.noise_floor_dBm() >= base.noise_floor_dBm() + 19.0

--- a/tests/test_loraphy_rng.py
+++ b/tests/test_loraphy_rng.py
@@ -1,7 +1,7 @@
-import random
 from simulateur_lora_sfrd.phy import LoRaPHY
 from simulateur_lora_sfrd.loranode import Node
 from simulateur_lora_sfrd.launcher.channel import Channel
+from traffic.rng_manager import RngManager
 
 
 def test_loraphy_transmit_deterministic():
@@ -11,10 +11,10 @@ def test_loraphy_transmit_deterministic():
     n2 = Node(1, 0, 0, 7, 14, channel=ch2)
 
     phy = LoRaPHY(n1)
-    rng1 = random.Random(123)
-    random.seed(0)
+    mgr1 = RngManager(0)
+    rng1 = mgr1.get_stream("phy", 0)
     res1 = phy.transmit(n2, 20, rng=rng1)
-    rng2 = random.Random(123)
-    random.seed(0)
+    mgr2 = RngManager(0)
+    rng2 = mgr2.get_stream("phy", 0)
     res2 = phy.transmit(n2, 20, rng=rng2)
     assert res1 == res2

--- a/tests/test_smooth_mobility_rng.py
+++ b/tests/test_smooth_mobility_rng.py
@@ -1,0 +1,19 @@
+from simulateur_lora_sfrd.launcher.smooth_mobility import SmoothMobility
+from simulateur_lora_sfrd.launcher.node import Node
+from traffic.rng_manager import RngManager
+
+
+def test_smooth_mobility_determinism():
+    mgr1 = RngManager(42)
+    mob1 = SmoothMobility(100.0, rng=mgr1.get_stream("mob", 0))
+    node1 = Node(1, 0.0, 0.0, 7, 14)
+    mob1.assign(node1)
+    path1 = node1.path
+
+    mgr2 = RngManager(42)
+    mob2 = SmoothMobility(100.0, rng=mgr2.get_stream("mob", 0))
+    node2 = Node(1, 0.0, 0.0, 7, 14)
+    mob2.assign(node2)
+    path2 = node2.path
+
+    assert path1 == path2


### PR DESCRIPTION
## Summary
- allow injection of `np.random.Generator` in LoRaPHY, channel and advanced channel
- propagate RNG control to mobility models and planners
- add deterministic smooth mobility test
- update existing tests for new RNG usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688579f4d32c833181134ba53d08dc96