### PR TITLE
Add KS test for Poisson arrival intervals

### DIFF
--- a/tests/test_interval_ks.py
+++ b/tests/test_interval_ks.py
@@ -1,0 +1,27 @@
+import pytest
+
+scipy = pytest.importorskip("scipy")
+from scipy.stats import kstest, expon
+
+from simulateur_lora_sfrd.launcher.simulator import Simulator
+
+
+def test_poisson_interval_kstest():
+    mean_interval = 5.0
+    packets = 1000
+    sim = Simulator(
+        num_nodes=1,
+        num_gateways=1,
+        transmission_mode="Random",
+        packet_interval=mean_interval,
+        packets_to_send=packets,
+        pure_poisson_mode=True,
+        mobility=False,
+        seed=42,
+    )
+    sim.run()
+    node = sim.nodes[0]
+    times = [entry["tx_time"] for entry in node.interval_log]
+    intervals = [t1 - t0 for t0, t1 in zip(times, times[1:])]
+    stat, p = kstest(intervals, expon(scale=mean_interval).cdf)
+    assert p >= 0.05


### PR DESCRIPTION
## Summary
- add `test_interval_ks.py` to validate Poisson arrival intervals using `scipy.stats.kstest`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68857a6ae7a08331bf210291aa3384d8