### PR TITLE
Add KS test with SciPy

### DIFF
--- a/tests/test_interval_distribution.py
+++ b/tests/test_interval_distribution.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 import math
+from scipy import stats
 
 from traffic.exponential import sample_interval
 
@@ -68,6 +69,16 @@ def test_interval_distribution_ks(seed: int) -> None:
     samples = [sample_interval(mean_interval, rng) for _ in range(count)]
     p = _ks_p_value(samples, mean_interval)
     assert p > 0.05
+
+@pytest.mark.parametrize("seed", range(10))
+def test_interval_distribution_kstest(seed: int) -> None:
+    mean_interval = 10.0
+    count = 10_000
+    rng = np.random.Generator(np.random.MT19937(seed))
+    samples = [sample_interval(mean_interval, rng) for _ in range(count)]
+    statistic, p = stats.kstest(samples, "expon", args=(0, mean_interval))
+    assert p >= 0.05
+
 
 
 def test_sample_interval_seed_reproducibility() -> None:


### PR DESCRIPTION
## Summary
- add `scipy` import
- test `sample_interval` distribution with SciPy's `kstest`

## Testing
- `pytest -k interval_distribution -q` *(fails: ModuleNotFoundError: No module named 'scipy')*

------
https://chatgpt.com/codex/tasks/task_e_6885ffe3c4c08331ae549369055c4dd6