### PR TITLE
Fix RNG argument order

### DIFF
--- a/simulateur_lora_sfrd/launcher/node.py
+++ b/simulateur_lora_sfrd/launcher/node.py
@@ -403,8 +403,8 @@ class Node:
     def ensure_poisson_arrivals(
         self,
         up_to: float,
-        rng: "np.random.Generator",
         mean_interval: float,
+        rng: "np.random.Generator | None" = None,
         min_interval: float = 0.0,
         variation: float = 0.0,
         limit: int | None = None,
@@ -417,6 +417,11 @@ class Node:
         next transmission to occur after the previous airtime. ``variation``
         applies a multiplicative jitter factor to each accepted interval.
         """
+        if rng is None:
+            rng = self.rng
+        assert isinstance(rng, np.random.Generator) and isinstance(
+            rng.bit_generator, np.random.MT19937
+        ), "rng must be numpy.random.Generator using MT19937"
         assert isinstance(mean_interval, float) and mean_interval > 0, (
             "mean_interval must be positive float"
         )
@@ -463,9 +468,9 @@ class Node:
 
     def precompute_poisson_arrivals(
         self,
-        rng: "np.random.Generator",
         mean_interval: float,
         count: int,
+        rng: "np.random.Generator | None" = None,
         *,
         variation: float = 0.0,
     ) -> None:
@@ -479,8 +484,8 @@ class Node:
         self._arrival_index = 0
         self.ensure_poisson_arrivals(
             float("inf"),
-            rng,
             mean_interval,
+            rng,
             min_interval=0.0,
             variation=variation,
             limit=count,

--- a/simulateur_lora_sfrd/launcher/simulator.py
+++ b/simulateur_lora_sfrd/launcher/simulator.py
@@ -537,16 +537,16 @@ class Simulator:
                             "lock_step_poisson requires packets_to_send > 0"
                         )
                     node.precompute_poisson_arrivals(
-                        self.interval_rng,
                         self.packet_interval,
                         self.packets_to_send,
+                        self.interval_rng,
                         variation=self.interval_variation,
                     )
                 else:
                     node.ensure_poisson_arrivals(
                         node.last_tx_time,
-                        self.interval_rng,
                         self.first_packet_interval,
+                        self.interval_rng,
                         min_interval=max(
                             node.last_airtime, self.first_packet_min_delay
                         ),
@@ -937,8 +937,8 @@ class Simulator:
                         if not self.lock_step_poisson:
                             node.ensure_poisson_arrivals(
                                 node.last_tx_time,
-                                self.interval_rng,
                                 self.packet_interval,
+                                self.interval_rng,
                                 variation=self.interval_variation,
                                 limit=(
                                     self.packets_to_send

--- a/tests/test_interval_asserts.py
+++ b/tests/test_interval_asserts.py
@@ -17,8 +17,8 @@ def test_node_poisson_assert():
     rng = np.random.Generator(np.random.MT19937(0))
     node = Node(0, 0, 0, 7, 20)
     with pytest.raises(AssertionError):
-        node.ensure_poisson_arrivals(10.0, rng, -5.0)
+        node.ensure_poisson_arrivals(10.0, -5.0, rng)
     with pytest.raises(AssertionError):
-        node.ensure_poisson_arrivals(10.0, rng, 5)
+        node.ensure_poisson_arrivals(10.0, 5, rng)
     with pytest.raises(AssertionError):
-        node.ensure_poisson_arrivals(10.0, rng, 5.0, variation=-1.0)
+        node.ensure_poisson_arrivals(10.0, 5.0, rng, variation=-1.0)

--- a/tests/test_interval_jitter.py
+++ b/tests/test_interval_jitter.py
@@ -6,7 +6,7 @@ from simulateur_lora_sfrd.launcher.node import Node
 def test_jitter_multiplier():
     rng = np.random.Generator(np.random.MT19937(0))
     node = Node(0, 0, 0, 7, 20)
-    node.ensure_poisson_arrivals(10.0, rng, 1.0, variation=0.5, limit=1)
+    node.ensure_poisson_arrivals(10.0, 1.0, rng, variation=0.5, limit=1)
     delta = node.arrival_queue[0]
 
     rng2 = np.random.Generator(np.random.MT19937(0))

--- a/tests/test_min_interval.py
+++ b/tests/test_min_interval.py
@@ -25,7 +25,7 @@ def test_next_event_after_airtime():
 def test_poisson_min_interval_resampling():
     rng = np.random.Generator(np.random.MT19937(0))
     node = Node(0, 0, 0, 7, 20)
-    node.ensure_poisson_arrivals(10.0, rng, 0.1, min_interval=1.0, limit=10)
+    node.ensure_poisson_arrivals(10.0, 0.1, rng, min_interval=1.0, limit=10)
     last = 0.0
     for t in node.arrival_queue:
         assert t - last >= 1.0

--- a/tests/test_seed_stability.py
+++ b/tests/test_seed_stability.py
@@ -9,7 +9,7 @@ def _intervals_hash(seed: int, mean_interval: float = 1.0, count: int = 10000) -
     rng = RngManager(seed).get_stream("traffic", 0)
     node = Node(0, 0, 0, 7, 14)
     node.ensure_poisson_arrivals(
-        1e9, rng, mean_interval, min_interval=0.0, limit=count
+        1e9, mean_interval, rng, min_interval=0.0, limit=count
     )
     h = hashlib.sha256()
     last = 0.0


### PR DESCRIPTION
## Summary
- use node RNG by default in `ensure_poisson_arrivals`
- adapt `precompute_poisson_arrivals` and simulator calls
- update affected tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68860acd3a348331a3cdeb5cbd1f8e0b