### PR TITLE
Fix RNG manager for NumPy 1.26+

### DIFF
--- a/traffic/rng_manager.py
+++ b/traffic/rng_manager.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import hashlib
 import random
 import secrets
-import weakref
+# Use a regular set instead of WeakSet because numpy.random.Generator
+# does not support weak references in some numpy versions.
 import numpy as np
 from typing import Dict, Tuple
 
@@ -34,7 +35,7 @@ class RngManager:
         return self._streams[key]
 
 
-_allowed_generators: "weakref.WeakSet[np.random.Generator]" = weakref.WeakSet()
+_allowed_generators: "set[np.random.Generator]" = set()
 _hook_enabled = False
 _orig_random_funcs: dict[str, object] = {}
 _orig_numpy_methods: dict[str, object] = {}


### PR DESCRIPTION
## Summary
- adjust `rng_manager` to use a normal `set` instead of a `WeakSet`
- add comment explaining the reason

This resolves a `TypeError` when launching the dashboard in Python 3.12 with recent NumPy versions.

## Testing
- `pytest tests/test_rng_manager.py -q`
- `pytest -k rng_manager -q`


------
https://chatgpt.com/codex/tasks/task_e_688668275ff88331b9577dfc4a912b38