### PR TITLE
Activate node ADR and remove PER-based trigger

### DIFF
--- a/simulateur_lora_sfrd/launcher/adr_standard_1.py
+++ b/simulateur_lora_sfrd/launcher/adr_standard_1.py
@@ -39,7 +39,7 @@ def apply(sim: Simulator, *, degrade_channel: bool = False) -> None:
     """
     Simulator.MARGIN_DB = 15.0
     server.MARGIN_DB = Simulator.MARGIN_DB
-    sim.adr_node = False
+    sim.adr_node = True
     sim.adr_server = True
     # Utilise la moyenne de SNR sur 20 paquets comme dans FLoRa
     sim.adr_method = "avg"


### PR DESCRIPTION
## Summary
- enable node-side ADR in `adr_standard_1` so nodes send ADR_ACK_REQ as in FLoRa
- drop PER based ADR trigger in `Simulator`
- keep server-side ADR and compute margin only after 20 packets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68868079483883319b8f3371213dec72