### PR TITLE
Align server ADR algorithm with FLoRa

### DIFF
--- a/simulateur_lora_sfrd/launcher/server.py
+++ b/simulateur_lora_sfrd/launcher/server.py
@@ -410,29 +410,28 @@ class NetworkServer:
                     nstep = round(margin / 3.0)
 
                     sf = node.sf
-                    power = node.tx_power
-                    p_idx = DBM_TO_TX_POWER_INDEX.get(int(power), 0)
+                    p_idx = DBM_TO_TX_POWER_INDEX.get(int(node.tx_power), 0)
+                    max_power_index = max(TX_POWER_INDEX_TO_DBM.keys())
 
                     if nstep > 0:
-                        while nstep > 0 and (
-                            sf > 7 or p_idx < max(TX_POWER_INDEX_TO_DBM.keys())
-                        ):
-                            if sf > 7:
-                                sf -= 1
-                            elif p_idx < max(TX_POWER_INDEX_TO_DBM.keys()):
-                                p_idx += 1
-                                power = TX_POWER_INDEX_TO_DBM[p_idx]
+                        while nstep > 0 and sf > 7:
+                            sf -= 1
+                            nstep -= 1
+                        while nstep > 0 and p_idx < max_power_index:
+                            p_idx += 1
                             nstep -= 1
                     elif nstep < 0:
-                        while nstep < 0 and (p_idx > 0 or sf < 12):
-                            if p_idx > 0:
-                                p_idx -= 1
-                                power = TX_POWER_INDEX_TO_DBM[p_idx]
-                            elif sf < 12:
-                                sf += 1
+                        while nstep < 0 and p_idx > 0:
+                            p_idx -= 1
+                            nstep += 1
+                        while nstep < 0 and sf < 12:
+                            sf += 1
                             nstep += 1
 
+                    power = TX_POWER_INDEX_TO_DBM.get(p_idx, node.tx_power)
                     if sf != node.sf or power != node.tx_power:
+                        node.sf = sf
+                        node.tx_power = power
                         self.send_downlink(
                             node, adr_command=(sf, power, node.chmask, node.nb_trans)
                         )


### PR DESCRIPTION
## Summary
- update ADR logic to follow FLoRa algorithm exactly
- adjust SF and tx power in 3 dB steps

## Testing
- `pytest -q tests/test_adr.py::test_adr_decreases_sf_with_good_link -q`
- `pytest -q tests/test_adr.py::test_adr_increases_sf_with_poor_link -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68868979e168833189ab7f39bbfb09e5