### PR TITLE
Update FLoRa radio defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,9 +493,11 @@ différence de puissance exigée dépend alors des Spreading Factors en présenc
 
 Pour reproduire un scénario FLoRa :
 1. Passez `flora_mode=True` et `flora_timing=True` lors de la création du
-   `Simulator` (ou activez **Mode FLoRa complet**). Cela applique un seuil de
-   détection à -110 dBm, une fenêtre d'interférence de 5 s ainsi qu'un délai
-   réseau de 10 ms et un traitement serveur de 1,2 s comme dans OMNeT++.
+   `Simulator` (ou activez **Mode FLoRa complet**). Le canal radio utilise alors
+   le modèle log-normal de FLoRa avec un fading Rayleigh léger
+   (`multipath_taps=3`), un seuil de détection fixé à `-110 dBm` et une fenêtre
+   d'interférence minimale de `5 s`. Le délai réseau est également de 10 ms avec
+   un traitement serveur de 1,2 s comme dans OMNeT++.
 2. Appliquez l'algorithme ADR1 via `from simulateur_lora_sfrd.launcher.adr_standard_1 import apply as adr1` puis `adr1(sim)`.
    Cette fonction reprend la logique du serveur FLoRa original.
 3. Spécifiez `adr_method="avg"` lors de la création du `Simulator` (ou sur

--- a/simulateur_lora_sfrd/launcher/simulator.py
+++ b/simulateur_lora_sfrd/launcher/simulator.py
@@ -314,6 +314,9 @@ class Simulator:
                             ch.path_loss_d0,
                             ch.reference_distance,
                         ) = Channel.ENV_PRESETS["flora"]
+                for ch in self.multichannel.channels:
+                    if flora_mode and ch.multipath_taps <= 1:
+                        ch.multipath_taps = 3
         else:
             if channels is None:
                 env = "flora" if (flora_mode or phy_model.startswith("flora")) else None
@@ -324,6 +327,7 @@ class Simulator:
                         phy_model=ch_phy_model,
                         environment=env,
                         flora_loss_model=flora_loss_model,
+                        multipath_taps=3 if flora_mode else 1,
                     )
                 ]
             else:
@@ -344,6 +348,8 @@ class Simulator:
                                 ch.path_loss_d0,
                                 ch.reference_distance,
                             ) = Channel.ENV_PRESETS["flora"]
+                        if flora_mode and ch.multipath_taps <= 1:
+                            ch.multipath_taps = 3
                         ch_list.append(ch)
                     else:
                         ch_list.append(
@@ -357,6 +363,7 @@ class Simulator:
                                     else None
                                 ),
                                 flora_loss_model=flora_loss_model,
+                                multipath_taps=3 if flora_mode else 1,
                             )
                         )
             self.multichannel = MultiChannel(ch_list, method=channel_distribution)

--- a/tests/test_flora_defaults.py
+++ b/tests/test_flora_defaults.py
@@ -5,3 +5,7 @@ def test_default_intervals_flora_mode():
     sim = Simulator(flora_mode=True)
     assert sim.packet_interval == 1000.0
     assert sim.first_packet_interval == 1000.0
+    assert sim.detection_threshold_dBm == -110.0
+    assert sim.min_interference_time == 5.0
+    assert sim.channel.environment == "flora"
+    assert sim.channel.multipath_taps == 3


### PR DESCRIPTION
## Summary
- use FLoRa log-normal model with light Rayleigh fading when `flora_mode` is enabled
- document the new behaviour in the README
- verify defaults in `test_flora_defaults`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688689c94e7483318761b3f3ad1bd36d