### PR TITLE
Unify first packet interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,6 @@ scénarios FLoRa. Voici la liste complète des options :
   La valeur par défaut est `100` s.
 - `first_packet_interval` : moyenne exponentielle appliquée uniquement au
   premier envoi (`None` pour reprendre `packet_interval`). Par défaut `100` s.
-- `first_packet_min_delay` : délai minimal avant la première transmission (s).
 - `interval_variation`: coefficient de jitter appliqué multiplicativement
   à l'intervalle exponentiel (0 par défaut pour coller au comportement FLoRa). L'intervalle est multiplié par `1 ± U` avec `U` échantillonné dans `[-interval_variation, interval_variation]`.
  - Les instants de transmission suivent strictement une loi exponentielle de

--- a/simulateur_lora_sfrd/launcher/config_loader.py
+++ b/simulateur_lora_sfrd/launcher/config_loader.py
@@ -138,10 +138,15 @@ def parse_flora_interval(path: str | Path) -> float | None:
 def parse_flora_first_interval(path: str | Path) -> float | None:
     """Return the mean delay before the first packet defined in a FLoRa INI.
 
-    The INI parameter ``timeToFirstPacket`` is expected in the form
-    ``exponential(<value>s)``. When present, ``<value>`` is returned as a float.
-    ``None`` is returned if the parameter cannot be found.
+    ``timeToFirstPacket`` is ignored when ``timeToNextPacket`` is present.  This
+    helper therefore returns the same value as :func:`parse_flora_interval`
+    whenever possible so that the first packet uses the same mean interval as
+    the subsequent ones.
     """
+
+    next_val = parse_flora_interval(path)
+    if next_val is not None:
+        return next_val
 
     text = Path(path).read_text()
     match = re.search(r"timeToFirstPacket\s*=\s*exponential\((\d+(?:\.\d+)?)s\)", text)

--- a/simulateur_lora_sfrd/launcher/simulator.py
+++ b/simulateur_lora_sfrd/launcher/simulator.py
@@ -75,7 +75,6 @@ class Simulator:
         transmission_mode: str = "Random",
         packet_interval: float = 60.0,
         first_packet_interval: float | None = None,
-        first_packet_min_delay: float = 0.0,
         warm_up_intervals: int = 0,
         log_mean_after: int | None = None,
         interval_variation: float = 0.0,
@@ -125,7 +124,6 @@ class Simulator:
         :param transmission_mode: 'Random' pour transmissions aléatoires (Poisson) ou 'Periodic' pour périodiques.
         :param packet_interval: Intervalle moyen entre transmissions (si Random, moyenne en s; si Periodic, période fixe en s).
         :param first_packet_interval: Intervalle moyen appliqué uniquement au tout premier envoi (``None`` pour utiliser ``packet_interval``).
-        :param first_packet_min_delay: Délai minimal avant la première transmission (s).
         :param warm_up_intervals: Nombre d'intervalles à ignorer dans les métriques (warm-up).
         :param log_mean_after: Nombre d'intervalles comptabilisés après warm-up
             avant journalisation de la moyenne empirique (``None`` pour désactiver).
@@ -210,7 +208,8 @@ class Simulator:
             if first_packet_interval is not None
             else packet_interval
         )
-        self.first_packet_min_delay = first_packet_min_delay
+        # Minimal delay before the first transmission (5 s in FLoRa mode)
+        self.first_packet_min_delay = 0.0
         self.warm_up_intervals = warm_up_intervals
         self.log_mean_after = log_mean_after
         if interval_variation < 0 or interval_variation > 3:
@@ -543,7 +542,7 @@ class Simulator:
                 else:
                     node.ensure_poisson_arrivals(
                         node.last_tx_time,
-                        self.first_packet_interval,
+                        self.packet_interval,
                         self.interval_rng,
                         min_interval=max(
                             node.last_airtime, self.first_packet_min_delay

--- a/tests/test_flora_interval.py
+++ b/tests/test_flora_interval.py
@@ -12,10 +12,11 @@ def test_flora_ini_interval_parsing():
     ini_path = Path('flora-master/simulations/examples/n100-gw1.ini')
     next_mean = parse_flora_interval(ini_path)
     first_mean = parse_flora_first_interval(ini_path)
-    assert next_mean is not None and first_mean is not None
+    assert next_mean is not None
+    assert first_mean == next_mean
     nodes, gws, next_from_load, first_from_load = load_config(ini_path)
     assert next_from_load == next_mean
-    assert first_from_load == first_mean
+    assert first_from_load == next_mean
     sim = Simulator(flora_mode=True, config_file=str(ini_path))
     assert sim.packet_interval == next_mean
-    assert sim.first_packet_interval == first_mean
+    assert sim.first_packet_interval == sim.packet_interval

--- a/tests/test_write_flora_ini.py
+++ b/tests/test_write_flora_ini.py
@@ -11,4 +11,4 @@ def test_write_intervals(tmp_path):
     gateways = [{"x": 3.0, "y": 4.0}]
     write_flora_ini(nodes, gateways, ini, next_interval=7.5, first_interval=1.5)
     assert parse_flora_interval(ini) == 7.5
-    assert parse_flora_first_interval(ini) == 1.5
+    assert parse_flora_first_interval(ini) == 7.5


### PR DESCRIPTION
## Summary
- remove the `first_packet_min_delay` parameter
- default `first_packet_interval` to `packet_interval`
- always use `packet_interval` for initial arrival generation
- ignore `timeToFirstPacket` when reading FLoRa INI files
- adjust tests for the unified behaviour

## Testing
- `pytest -q tests/test_first_interval.py tests/test_flora_interval.py tests/test_write_flora_ini.py`

------
https://chatgpt.com/codex/tasks/task_e_68868a0150b883319cb31dd98e7c987f