### PR TITLE
Add slope constraints to mobility models

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,11 @@ Plusieurs schémas supplémentaires peuvent être utilisés :
   de terrain et sur des obstacles dynamiques optionnels.
 - `PlannedRandomWaypoint` applique la même logique mais choisit un point d'arrivée
   aléatoire puis planifie un chemin en A* pour contourner un relief 3D ou des
-  obstacles fixes.
+  obstacles fixes. Une option `slope_limit` permet d'éviter les pentes trop fortes.
 - `TerrainMapMobility` permet désormais de suivre une carte rasterisée en
   pondérant la vitesse par cellule et en tenant compte d'obstacles 3D.
+- `PathMobility` et le planificateur A* acceptent également un `slope_limit`
+  pour ignorer les transitions dépassant une inclinaison donnée.
 - `GaussMarkov` et les traces GPS restent disponibles pour modéliser des
   mouvements plus spécifiques.
 

--- a/simulateur_lora_sfrd/launcher/planned_random_waypoint.py
+++ b/simulateur_lora_sfrd/launcher/planned_random_waypoint.py
@@ -22,6 +22,7 @@ class PlannedRandomWaypoint:
         obstacle_height_map: str | Path | Iterable[Iterable[float]] | None = None,
         max_height: float = 0.0,
         slope_scale: float = 0.1,
+        slope_limit: float | None = None,
         rng: np.random.Generator | None = None,
     ) -> None:
         if terrain is None:
@@ -33,6 +34,9 @@ class PlannedRandomWaypoint:
         if obstacle_height_map is not None and isinstance(obstacle_height_map, (str, Path)):
             obstacle_height_map = load_map(obstacle_height_map)
         self.rng = rng or np.random.Generator(np.random.MT19937())
+        """\
+        :param slope_limit: Pente maximale à éviter lors du calcul des chemins.
+        """
         self.planner = WaypointPlanner3D(
             area_size,
             terrain,
@@ -40,6 +44,7 @@ class PlannedRandomWaypoint:
             obstacle_height_map=obstacle_height_map,
             max_height=max_height,
             slope_scale=slope_scale,
+            slope_limit=slope_limit,
             rng=self.rng,
         )
         self.area_size = float(area_size)


### PR DESCRIPTION
## Summary
- extend `RandomWaypoint`, `PathMobility`, `TerrainMapMobility` and `PlannedRandomWaypoint`
- improve `WaypointPlanner3D` with slope checks
- document new `slope_limit` parameter in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886b7eccab8833186e50bdb8ecec168