### PR TITLE
Improve radio energy modeling

### DIFF
--- a/simulateur_lora_sfrd/launcher/energy_profiles.py
+++ b/simulateur_lora_sfrd/launcher/energy_profiles.py
@@ -13,11 +13,17 @@ DEFAULT_TX_CURRENT_MAP_A: dict[float, float] = {
 @dataclass(frozen=True)
 class EnergyProfile:
     """Energy consumption parameters for a LoRa node."""
+
     voltage_v: float = 3.3
     sleep_current_a: float = 1e-6
     rx_current_a: float = 11e-3
     listen_current_a: float = 0.0
     process_current_a: float = 0.0
+    # Additional radio state modelling parameters
+    startup_current_a: float = 0.0
+    startup_time_s: float = 0.0
+    preamble_current_a: float = 0.0
+    preamble_time_s: float = 0.0
     ramp_up_s: float = 0.0
     ramp_down_s: float = 0.0
     rx_window_duration: float = 0.0


### PR DESCRIPTION
## Summary
- add startup and preamble currents to energy profiles
- track new energy categories per-node
- account for startup, listening and preamble energy consumption in simulator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886d9c7e3048331bcd9d3b46eb63d6b