### PR TITLE
Expand mobility and channel models

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Plusieurs schémas supplémentaires peuvent être utilisés :
   pour ignorer les transitions dépassant une inclinaison donnée.
 - `GaussMarkov` et les traces GPS restent disponibles pour modéliser des
   mouvements plus spécifiques.
+- `Trace3DMobility` lit une trace temporelle et suit le relief 3D en bloquant
+  les passages au-dessus d'une hauteur maximale.
 
 ## Multi-canaux
 
@@ -369,6 +371,8 @@ Une ``obstacle_map`` peut désormais contenir des identifiants (par
 exemple ``wall`` ou ``building``) associés à des pertes définies via le
 paramètre ``obstacle_losses`` pour modéliser précisément les obstacles
 traversés.
+Un paramètre ``obstacle_variability_std_dB`` ajoute une variation
+temporelle corrélée de cette absorption pour simuler un canal évolutif.
 Il est désormais possible de modéliser la sélectivité du filtre RF grâce aux
 paramètres ``frontend_filter_order`` et ``frontend_filter_bw``. Une valeur non
 nulle applique une atténuation dépendante du décalage fréquentiel, permettant de

--- a/simulateur_lora_sfrd/launcher/__init__.py
+++ b/simulateur_lora_sfrd/launcher/__init__.py
@@ -14,6 +14,7 @@ from .path_mobility import PathMobility
 from .terrain_mobility import TerrainMapMobility
 from .gauss_markov import GaussMarkov
 from .gps_mobility import GPSTraceMobility, MultiGPSTraceMobility
+from .trace3d_mobility import Trace3DMobility
 from .map_loader import load_map
 from .lorawan import LoRaWANFrame, compute_rx1, compute_rx2
 from .downlink_scheduler import DownlinkScheduler
@@ -37,6 +38,7 @@ __all__ = [
     "PathMobility",
     "TerrainMapMobility",
     "GaussMarkov",
+    "Trace3DMobility",
     "GPSTraceMobility",
     "MultiGPSTraceMobility",
     "load_map",

--- a/simulateur_lora_sfrd/launcher/trace3d_mobility.py
+++ b/simulateur_lora_sfrd/launcher/trace3d_mobility.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from .gps_mobility import GPSTraceMobility
+from .map_loader import load_map
+
+
+class Trace3DMobility(GPSTraceMobility):
+    """Follow a time stamped trace while using 3D maps for altitude and obstacles."""
+
+    def __init__(
+        self,
+        area_size: float,
+        trace: str | Iterable[Sequence[float]],
+        *,
+        elevation: str | Path | Iterable[Iterable[float]] | None = None,
+        obstacle_height_map: str | Path | Iterable[Iterable[float]] | None = None,
+        max_height: float = 0.0,
+        loop: bool = True,
+    ) -> None:
+        super().__init__(trace, loop=loop)
+        self.area_size = float(area_size)
+        if elevation is not None and not isinstance(elevation, list):
+            elevation = load_map(elevation)
+        self.elevation = elevation
+        if elevation:
+            self.e_rows = len(elevation)
+            self.e_cols = len(elevation[0]) if self.e_rows else 0
+        else:
+            self.e_rows = self.e_cols = 0
+        if obstacle_height_map is not None and not isinstance(obstacle_height_map, list):
+            obstacle_height_map = load_map(obstacle_height_map)
+        self.obstacle_height_map = obstacle_height_map
+        self.max_height = float(max_height)
+        if obstacle_height_map:
+            self.h_rows = len(obstacle_height_map)
+            self.h_cols = len(obstacle_height_map[0]) if self.h_rows else 0
+        else:
+            self.h_rows = self.h_cols = 0
+
+    # ------------------------------------------------------------------
+    def _elevation(self, x: float, y: float) -> float:
+        if not self.elevation or self.e_rows == 0 or self.e_cols == 0:
+            return 0.0
+        cx = int(x / self.area_size * self.e_cols)
+        cy = int(y / self.area_size * self.e_rows)
+        cx = min(max(cx, 0), self.e_cols - 1)
+        cy = min(max(cy, 0), self.e_rows - 1)
+        return float(self.elevation[cy][cx])
+
+    def _height(self, x: float, y: float) -> float:
+        if not self.obstacle_height_map or self.h_rows == 0 or self.h_cols == 0:
+            return 0.0
+        cx = int(x / self.area_size * self.h_cols)
+        cy = int(y / self.area_size * self.h_rows)
+        cx = min(max(cx, 0), self.h_cols - 1)
+        cy = min(max(cy, 0), self.h_rows - 1)
+        return float(self.obstacle_height_map[cy][cx])
+
+    # ------------------------------------------------------------------
+    def move(self, node, current_time: float) -> None:
+        prev_x, prev_y, prev_alt = node.x, node.y, node.altitude
+        super().move(node, current_time)
+        if self.elevation:
+            node.altitude = self._elevation(node.x, node.y)
+        if self.obstacle_height_map:
+            height = self._height(node.x, node.y)
+            if height > self.max_height and node.altitude <= height:
+                node.x, node.y, node.altitude = prev_x, prev_y, prev_alt
+            else:
+                node.altitude = max(node.altitude, height)


### PR DESCRIPTION
## Summary
- add `Trace3DMobility` for following traces with 3D maps
- support obstacle absorption variability in `AdvancedChannel`
- document new mobility and channel options in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68875946055c8331ad1cd0d251488816