### PR TITLE
Replace energy model with OmnetPHY estimation

### DIFF
--- a/tests/test_run_simulate.py
+++ b/tests/test_run_simulate.py
@@ -17,7 +17,7 @@ def test_simulate_single_node_periodic():
     assert delivered == 10
     assert collisions == 0
     assert pdr == 100.0
-    assert energy == 10.0
+    assert pytest.approx(energy, rel=1e-6) == 0.132619833984
     assert avg_delay == 0
     assert throughput == PAYLOAD_SIZE * 8 * delivered / 10
 


### PR DESCRIPTION
## Summary
- compute energy consumption using OmnetPHY parameters
- expose voltage and current options in CLI
- adjust CSV output and logs for Joule units
- update test expectation for new energy model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887b1871a788331988acf288977ec6a