### PR TITLE
Add directional antenna gain

### DIFF
--- a/simulateur_lora_sfrd/launcher/gateway.py
+++ b/simulateur_lora_sfrd/launcher/gateway.py
@@ -15,6 +15,8 @@ class Gateway:
         altitude: float = 0.0,
         *,
         rx_gain_dB: float = 0.0,
+        orientation_az: float = 0.0,
+        orientation_el: float = 0.0,
     ):
         """
         Initialise une passerelle LoRa.
@@ -33,6 +35,8 @@ class Gateway:
         self.y = y
         self.altitude = altitude
         self.rx_gain_dB = rx_gain_dB
+        self.orientation_az = orientation_az
+        self.orientation_el = orientation_el
         # Transmissions en cours indexées par (sf, frequency)
         self.active_map: dict[tuple[int, float], list[dict]] = {}
         # Mapping event_id -> (key, dict) for quick removal

--- a/simulateur_lora_sfrd/launcher/node.py
+++ b/simulateur_lora_sfrd/launcher/node.py
@@ -45,6 +45,8 @@ class Node:
         sf: int,
         tx_power: float,
         channel=None,
+        orientation_az: float = 0.0,
+        orientation_el: float = 0.0,
         devaddr: int | None = None,
         join_eui: int = 0,
         dev_eui: int | None = None,
@@ -89,6 +91,8 @@ class Node:
         self.x = x
         self.y = y
         self.altitude = 0.0
+        self.orientation_az = orientation_az
+        self.orientation_el = orientation_el
         self.initial_sf = sf
         self.sf = sf
         self.initial_tx_power = tx_power

--- a/simulateur_lora_sfrd/launcher/simulator.py
+++ b/simulateur_lora_sfrd/launcher/simulator.py
@@ -766,12 +766,21 @@ class Simulator:
                 kwargs = {
                     "freq_offset_hz": getattr(node, "current_freq_offset", 0.0),
                     "sync_offset_s": getattr(node, "current_sync_offset", 0.0),
+                    "tx_pos": (node.x, node.y, getattr(node, "altitude", 0.0)),
+                    "rx_pos": (gw.x, gw.y, getattr(gw, "altitude", 0.0)),
                 }
                 if hasattr(node.channel, "_obstacle_loss"):
-                    kwargs["tx_pos"] = (node.x, node.y, getattr(node, "altitude", 0.0))
-                    kwargs["rx_pos"] = (gw.x, gw.y, getattr(gw, "altitude", 0.0))
-                    kwargs["tx_angle"] = getattr(node, "direction", 0.0)
-                    kwargs["rx_angle"] = getattr(gw, "direction", 0.0)
+                    kwargs["tx_angle"] = getattr(node, "orientation_az", getattr(node, "direction", 0.0))
+                    kwargs["rx_angle"] = getattr(gw, "orientation_az", getattr(gw, "direction", 0.0))
+                else:
+                    kwargs["tx_angle"] = (
+                        getattr(node, "orientation_az", 0.0),
+                        getattr(node, "orientation_el", 0.0),
+                    )
+                    kwargs["rx_angle"] = (
+                        getattr(gw, "orientation_az", 0.0),
+                        getattr(gw, "orientation_el", 0.0),
+                    )
                 rssi, snr = node.channel.compute_rssi(
                     tx_power,
                     distance,
@@ -1046,14 +1055,24 @@ class Simulator:
                 if not frame:
                     continue
                 distance = node.distance_to(gw)
-                kwargs = {"freq_offset_hz": 0.0, "sync_offset_s": 0.0}
+                kwargs = {
+                    "freq_offset_hz": 0.0,
+                    "sync_offset_s": 0.0,
+                    "tx_pos": (gw.x, gw.y, getattr(gw, "altitude", 0.0)),
+                    "rx_pos": (node.x, node.y, getattr(node, "altitude", 0.0)),
+                }
                 if hasattr(node.channel, "_obstacle_loss"):
-                    kwargs["tx_pos"] = (gw.x, gw.y, getattr(gw, "altitude", 0.0))
-                    kwargs["rx_pos"] = (node.x, node.y, getattr(node, "altitude", 0.0))
-                    kwargs["tx_angle"] = getattr(gw, "direction", 0.0)
-                    kwargs["rx_angle"] = getattr(node, "direction", 0.0)
-                    kwargs["tx_angle"] = getattr(gw, "direction", 0.0)
-                    kwargs["rx_angle"] = getattr(node, "direction", 0.0)
+                    kwargs["tx_angle"] = getattr(gw, "orientation_az", getattr(gw, "direction", 0.0))
+                    kwargs["rx_angle"] = getattr(node, "orientation_az", getattr(node, "direction", 0.0))
+                else:
+                    kwargs["tx_angle"] = (
+                        getattr(gw, "orientation_az", 0.0),
+                        getattr(gw, "orientation_el", 0.0),
+                    )
+                    kwargs["rx_angle"] = (
+                        getattr(node, "orientation_az", 0.0),
+                        getattr(node, "orientation_el", 0.0),
+                    )
                 rssi, snr = node.channel.compute_rssi(
                     node.tx_power,
                     distance,


### PR DESCRIPTION
## Summary
- add orientation parameters to Node and Gateway
- compute angle-based gain in Channel
- pass orientation info in Simulator
- implement `_directional_gain` for antenna patterns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887b18c780883319a0deea53bb6a358