### PR TITLE
Add optional FLoRa noise table support

### DIFF
--- a/tests/test_flora_sensitivity.py
+++ b/tests/test_flora_sensitivity.py
@@ -27,3 +27,9 @@ def parse_flora_sensitivity():
 def test_flora_sensitivity_table_matches():
     expected = parse_flora_sensitivity()
     assert Channel.FLORA_SENSITIVITY == expected
+
+
+def test_flora_noise_path_loading():
+    path = Path('flora-master/src/LoRaPhy/LoRaAnalogModel.cc')
+    ch = Channel(flora_noise_path=path)
+    assert ch.flora_noise_table == parse_flora_sensitivity()


### PR DESCRIPTION
## Summary
- allow loading exact FLoRa background noise levels
- expose helper to parse LoRaAnalogModel.cc
- test loading of the noise table from file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a4384b8b48331b0e008b3a514ea2a