### PR TITLE
Support orientation-based gain and PA ramp energy

### DIFF
--- a/tests/test_startup_currents.py
+++ b/tests/test_startup_currents.py
@@ -35,3 +35,26 @@ def test_startup_current_energy():
 
     assert phy.radio_state == "IDLE"
 
+
+def test_pa_ramp_current_energy():
+    ch = Channel(
+        phy_model="omnet",
+        tx_current_a=1.0,
+        idle_current_a=0.0,
+        voltage_v=1.0,
+        pa_ramp_up_s=1.0,
+        pa_ramp_down_s=1.0,
+        pa_ramp_current_a=2.0,
+    )
+    phy = ch.omnet_phy
+    phy.tx_state = "off"
+    phy.start_tx()
+    phy.update(0.5)
+    assert phy.energy_tx == pytest.approx(1.0)
+    phy.update(0.5)
+    assert phy.tx_state == "on"
+    assert phy.energy_tx == pytest.approx(2.0)
+    phy.stop_tx()
+    phy.update(1.0)
+    assert phy.energy_tx == pytest.approx(4.0)
+


### PR DESCRIPTION
## Summary
- extend `OmnetPHY` and `Channel` to accept antenna models and PA ramp current
- propagate antenna model and ramp parameters from `Simulator`
- compute orientation dependent gains when using `OmnetPHY`
- account for energy used while ramping
- test PA ramp energy consumption

## Testing
- `pytest -k startup_currents -q`

------
https://chatgpt.com/codex/tasks/task_e_688b59f17210833188aad8025740820a