### PR TITLE
Increase capture window default to six symbols

### DIFF
--- a/simulateur_lora_sfrd/launcher/channel.py
+++ b/simulateur_lora_sfrd/launcher/channel.py
@@ -149,7 +149,7 @@ class Channel:
         bandwidth: float = 125e3,
         coding_rate: int = 1,
         capture_threshold_dB: float = 6.0,
-        capture_window_symbols: int = 5,
+        capture_window_symbols: int = 6,
         tx_power_std: float = 0.0,
         interference_dB: float = 0.0,
         detection_threshold_dBm: float = -float("inf"),
@@ -182,7 +182,8 @@ class Channel:
         :param coding_rate: Index de code (0=4/5 … 4=4/8).
         :param capture_threshold_dB: Seuil de capture pour le décodage simultané.
         :param capture_window_symbols: Nombre de symboles de préambule requis
-            avant qu'un paquet plus fort puisse capturer la réception.
+            avant qu'un paquet plus fort puisse capturer la réception (par
+            défaut 6).
         :param tx_power_std: Écart-type de la variation aléatoire de puissance TX.
         :param interference_dB: Bruit supplémentaire moyen dû aux interférences.
         :param detection_threshold_dBm: RSSI minimal détectable (dBm). Les

--- a/simulateur_lora_sfrd/launcher/flora_phy.py
+++ b/simulateur_lora_sfrd/launcher/flora_phy.py
@@ -77,7 +77,7 @@ class FloraPHY:
         The algorithm follows the same logic as ``LoRaReceiver`` in FLoRa:
         the strongest packet wins only if the power difference with each
         interferer is above the ``NON_ORTH_DELTA`` threshold *and* the
-        interferer overlaps past the ``preamble - 5`` symbols window.
+        interferer overlaps past the ``preamble - 6`` symbols window.
         """
 
         if not rssi_list:

--- a/simulateur_lora_sfrd/launcher/gateway.py
+++ b/simulateur_lora_sfrd/launcher/gateway.py
@@ -63,7 +63,7 @@ class Gateway:
         capture_mode: str = "basic",
         flora_phy=None,
         orthogonal_sf: bool = True,
-        capture_window_symbols: int = 5,
+        capture_window_symbols: int = 6,
     ):
         """
         Tente de démarrer la réception d'une nouvelle transmission sur cette passerelle.
@@ -86,7 +86,7 @@ class Gateway:
         :param orthogonal_sf: Si ``True``, les transmissions de SF différents
             sont ignorées pour la détection de collision.
         :param capture_window_symbols: Nombre de symboles de préambule exigés
-            avant qu'un paquet puisse capturer la réception.
+            avant qu'un paquet puisse capturer la réception (par défaut 6).
         """
         key = (sf, frequency)
         symbol_duration = (2 ** sf) / bandwidth

--- a/simulateur_lora_sfrd/launcher/simulator.py
+++ b/simulateur_lora_sfrd/launcher/simulator.py
@@ -855,7 +855,7 @@ class Simulator:
                         else None
                     ),
                     orthogonal_sf=node.channel.orthogonal_sf,
-                    capture_window_symbols=node.channel.capture_window_symbols,
+                    capture_window_symbols=node.channel.capture_window_symbols,  # default: 6
                 )
 
             # Retenir le meilleur RSSI/SNR mesuré pour cette transmission


### PR DESCRIPTION
## Summary
- bump capture window default from five to six symbols in channel and gateway
- document six-symbol capture window in gateway and simulator
- update Flora PHY comment to reference preamble – 6 window

## Testing
- `pytest -q --maxfail=1` *(fails: assert 8 == 12)*


------
https://chatgpt.com/codex/tasks/task_e_688e23f776e483318abf406586888233