### PR TITLE
Default to exact BER for FLoRa PHY

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,10 @@ Pour le mode OMNeT++, le taux d'erreur binaire est déterminé grâce à la
 fonction `calculateBER` de `LoRaModulation` transposée telle quelle en
 Python afin de reproduire fidèlement les performances de décodage.
 
+Le calcul BER exact est désormais **activé par défaut** dans `FloraPHY`. Passez
+`use_exact_ber=False` lors de sa construction pour revenir à l'approximation
+logistique si vous souhaitez accélérer les simulations.
+
 > **Remarque :** cette approche logistique reste une approximation des courbes
 > PER de FLoRa. La version C++ calcule la probabilité d'erreur binaire par
 > intégration dans `calculateBER`. Pour un réalisme maximal, compilez

--- a/simulateur_lora_sfrd/launcher/flora_phy.py
+++ b/simulateur_lora_sfrd/launcher/flora_phy.py
@@ -36,7 +36,7 @@ class FloraPHY:
     HATA_K2 = 35.2
     SNR_THRESHOLDS = {7: -7.5, 8: -10.0, 9: -12.5, 10: -15.0, 11: -17.5, 12: -20.0}
 
-    def __init__(self, channel, loss_model: str = "lognorm", *, use_exact_ber: bool = False) -> None:
+    def __init__(self, channel, loss_model: str = "lognorm", *, use_exact_ber: bool = True) -> None:
         self.channel = channel
         self.loss_model = loss_model
         self.use_exact_ber = bool(use_exact_ber)


### PR DESCRIPTION
## Summary
- enable exact BER computation in `FloraPHY` by default
- document how to disable the exact BER mode

## Testing
- `pytest` *(fails: module 'numpy' has no attribute '__version__')*


------
https://chatgpt.com/codex/tasks/task_e_688e23fd4aa48331963c1ffba59031a1