### PR TITLE
feat: allow selectable sensitivity model

### DIFF
--- a/simulateur_lora_sfrd/launcher/channel.py
+++ b/simulateur_lora_sfrd/launcher/channel.py
@@ -145,6 +145,7 @@ class Channel:
         idle_current_a: float = 0.0,
         voltage_v: float = 3.3,
         flora_noise_path: str | os.PathLike | None = None,
+        sensitivity_mode: str = "flora",
         *,
         bandwidth: float = 125e3,
         coding_rate: int = 1,
@@ -251,6 +252,8 @@ class Channel:
             n'interfèrent pas entre elles.
         :param flora_noise_path: Chemin vers un fichier ``LoRaAnalogModel.cc``
             pour charger la table de bruit FLoRa.
+        :param sensitivity_mode: "flora" pour utiliser les valeurs de bruit
+            issues de FLoRa, "theoretical" pour un calcul thermique.
         """
 
         if environment is not None:
@@ -330,6 +333,7 @@ class Channel:
         self.impulsive_noise_dB = float(impulsive_noise_dB)
         self.adjacent_interference_dB = float(adjacent_interference_dB)
         self.use_flora_curves = use_flora_curves
+        self.sensitivity_mode = sensitivity_mode
         self.tx_current_a = float(tx_current_a)
         self.rx_current_a = float(rx_current_a)
         self.idle_current_a = float(idle_current_a)
@@ -728,8 +732,13 @@ class Channel:
 
 
     def _update_sensitivity(self) -> None:
-        bw = min(self.bandwidth, self.frontend_filter_bw)
-        noise = -174 + 10 * math.log10(bw) + self.noise_figure_dB
-        self.sensitivity_dBm = {
-            sf: noise + snr for sf, snr in self.SNR_THRESHOLDS.items()
-        }
+        if self.sensitivity_mode == "theoretical":
+            bw = min(self.bandwidth, self.frontend_filter_bw)
+            noise = -174 + 10 * math.log10(bw) + self.noise_figure_dB
+            self.sensitivity_dBm = {
+                sf: noise + snr for sf, snr in self.SNR_THRESHOLDS.items()
+            }
+        else:
+            self.sensitivity_dBm = {
+                sf: self._flora_noise_dBm(sf) for sf in self.flora_noise_table
+            }

--- a/simulateur_lora_sfrd/launcher/tests/test_sensitivity.py
+++ b/simulateur_lora_sfrd/launcher/tests/test_sensitivity.py
@@ -2,8 +2,17 @@ import math
 from simulateur_lora_sfrd.launcher.channel import Channel
 
 
-def test_channel_sensitivity_values():
+def test_channel_sensitivity_flora():
     channel = Channel()
+    expected = {
+        sf: channel.flora_noise_table[sf][int(channel.bandwidth)]
+        for sf in channel.flora_noise_table
+    }
+    assert channel.sensitivity_dBm == expected
+
+
+def test_channel_sensitivity_theoretical():
+    channel = Channel(sensitivity_mode="theoretical")
     noise = -174 + 10 * math.log10(channel.bandwidth) + channel.noise_figure_dB
     expected = {sf: noise + snr for sf, snr in Channel.SNR_THRESHOLDS.items()}
     for sf, th in expected.items():

--- a/tests/test_multipath_models.py
+++ b/tests/test_multipath_models.py
@@ -13,7 +13,7 @@ def test_multipath_fading_mean():
 
 
 def test_sensitivity_matches_theory():
-    ch = Channel()
+    ch = Channel(sensitivity_mode="theoretical")
     bw = ch.bandwidth
     nf = ch.noise_figure_dB
     snr_req = {7: -7.5, 8: -10.0, 9: -12.5, 10: -15.0, 11: -17.5, 12: -20.0}

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -1,0 +1,14 @@
+import math
+from simulateur_lora_sfrd.launcher.channel import Channel
+
+
+def test_sensitivity_mode_switch():
+    ch_flora = Channel()
+    flora_expected = ch_flora.flora_noise_table[7][int(ch_flora.bandwidth)]
+    assert ch_flora.sensitivity_dBm[7] == flora_expected
+
+    ch_theoretical = Channel(sensitivity_mode="theoretical")
+    bw = ch_theoretical.bandwidth
+    noise = -174 + 10 * math.log10(bw) + ch_theoretical.noise_figure_dB
+    expected = noise + Channel.SNR_THRESHOLDS[7]
+    assert math.isclose(ch_theoretical.sensitivity_dBm[7], expected, abs_tol=0.1)


### PR DESCRIPTION
## Summary
- use FLoRa noise table to derive default channel sensitivity
- add `sensitivity_mode` option to switch between FLoRa and theoretical calculations
- extend tests to cover both approaches and new switch

## Testing
- `pytest tests/test_simulator.py tests/test_multipath_models.py simulateur_lora_sfrd/launcher/tests/test_sensitivity.py`
- `pytest` *(fails: AttributeError: module 'numpy' has no attribute 'dtype')*


------
https://chatgpt.com/codex/tasks/task_e_688e24037c00833188d30c0dc7b223bc