### PR TITLE
Simplify packet interval handling on dashboard

### DIFF
--- a/simulateur_lora_sfrd/launcher/dashboard.py
+++ b/simulateur_lora_sfrd/launcher/dashboard.py
@@ -116,12 +116,6 @@ mode_select = pn.widgets.RadioButtonGroup(
     name="Mode d'émission", options=["Aléatoire", "Périodique"], value="Aléatoire"
 )
 interval_input = pn.widgets.FloatInput(name="Intervalle moyen (s)", value=100.0, step=1.0, start=0.1)
-first_packet_input = pn.widgets.FloatInput(
-    name="Intervalle premier paquet (s)",
-    value=100.0,
-    step=1.0,
-    start=0.1,
-)
 packets_input = pn.widgets.IntInput(
     name="Nombre de paquets par nœud (0=infin)", value=80, step=1, start=0
 )
@@ -509,31 +503,6 @@ def on_mode_change(event):
 
 
 mode_select.param.watch(on_mode_change, "value")
-
-
-# --- Synchronisation de l'intervalle du premier paquet ---
-first_packet_user_edited = False
-_syncing_first_packet = False
-
-
-def on_interval_update(event):
-    global _syncing_first_packet
-    if not first_packet_user_edited:
-        _syncing_first_packet = True
-        first_packet_input.value = event.new
-        _syncing_first_packet = False
-
-
-def on_first_packet_change(event):
-    global first_packet_user_edited
-    if not _syncing_first_packet:
-        first_packet_user_edited = True
-
-
-interval_input.param.watch(on_interval_update, "value")
-first_packet_input.param.watch(on_first_packet_change, "value")
-
-
 # --- Sélection du profil ADR ---
 def _update_adr_badge(name: str) -> None:
     adr_active_badge.object = (
@@ -701,7 +670,6 @@ def setup_simulation(seed_offset: int = 0):
         area_size=float(area_input.value),
         transmission_mode="Random" if mode_select.value == "Aléatoire" else "Periodic",
         packet_interval=float(interval_input.value),
-        first_packet_interval=float(first_packet_input.value),
         packets_to_send=int(packets_input.value),
         adr_node=adr_node_checkbox.value,
         adr_server=adr_server_checkbox.value,
@@ -1266,7 +1234,6 @@ controls = pn.WidgetBox(
     area_input,
     mode_select,
     interval_input,
-    first_packet_input,
     packets_input,
     seed_input,
     num_runs_input,

--- a/tests/test_first_interval.py
+++ b/tests/test_first_interval.py
@@ -1,4 +1,3 @@
-import types
 import pytest
 
 from simulateur_lora_sfrd.launcher.simulator import Simulator
@@ -38,29 +37,6 @@ def test_cli_first_interval_overrides(monkeypatch):
         '--first-interval', '3'
     ])
     assert received['first_interval'] == 3.0
-
-
-# Test dashboard callback syncing behaviour
-
-def test_dashboard_first_interval_sync(monkeypatch):
-    pn = pytest.importorskip('panel')
-    dashboard = pytest.importorskip('simulateur_lora_sfrd.launcher.dashboard')
-
-    dashboard.first_packet_user_edited = False
-    dashboard._syncing_first_packet = False
-    dashboard.interval_input.value = 10
-    dashboard.first_packet_input.value = 10
-
-    event = types.SimpleNamespace(new=20)
-    dashboard.on_interval_update(event)
-    assert dashboard.first_packet_input.value == 20
-
-    # Simulate user edit breaking the link
-    event_fp = types.SimpleNamespace(new=25)
-    dashboard.on_first_packet_change(event_fp)
-    dashboard.interval_input.value = 30
-    dashboard.on_interval_update(types.SimpleNamespace(new=30))
-    assert dashboard.first_packet_input.value == 25
 
 
 def test_first_interval_matches_poisson():


### PR DESCRIPTION
## Summary
- remove "Intervalle premier paquet" field from dashboard
- rely on average interval for both first and next transmissions
- drop obsolete dashboard first-interval sync test

## Testing
- `pytest -q` *(fails: tests/test_flora_rssi.py::test_oulu_path_loss_model)*

------
https://chatgpt.com/codex/tasks/task_e_689094b625f4833191fb061dafd17fd1