### PR TITLE
Handle Channel objects in simulator setup and fix Oulu path loss randomness

### DIFF
--- a/simulateur_lora_sfrd/launcher/flora_phy.py
+++ b/simulateur_lora_sfrd/launcher/flora_phy.py
@@ -62,10 +62,11 @@ class FloraPHY:
             )
             sigma = (
                 self.channel.shadowing_std
-                if self.channel.shadowing_std > 0
+                if self.channel.shadowing_std >= 0
                 else self.OULU_SIGMA
             )
-            loss += random.gauss(0.0, sigma)
+            if sigma > 0:
+                loss += random.gauss(0.0, sigma)
         elif self.loss_model == "hata":
             loss = self.HATA_K1 + self.HATA_K2 * math.log10(d / 1000.0)
             if self.channel.shadowing_std > 0:

--- a/simulateur_lora_sfrd/launcher/simulator.py
+++ b/simulateur_lora_sfrd/launcher/simulator.py
@@ -391,19 +391,19 @@ class Simulator:
                             ch.multipath_taps = 3
                         ch.phase_noise_std_dB = phase_noise_std_dB
                         ch.clock_jitter_std_s = clock_jitter_std_s
-                    ch.pa_ramp_up_s = pa_ramp_up_s
-                    ch.pa_ramp_down_s = pa_ramp_down_s
-                    ch.pa_ramp_current_a = pa_ramp_current_a
-                    ch.antenna_model = antenna_model
-                    if hasattr(ch, "_phase_noise"):
-                        ch._phase_noise.std = phase_noise_std_dB
-                    if getattr(ch, "omnet_phy", None):
-                        ch.omnet_phy.clock_jitter_std_s = clock_jitter_std_s
-                        ch.omnet_phy.pa_ramp_up_s = pa_ramp_up_s
-                        ch.omnet_phy.pa_ramp_down_s = pa_ramp_down_s
-                        ch.omnet_phy.pa_ramp_current_a = pa_ramp_current_a
-                        ch.omnet_phy.antenna_model = antenna_model
-                        ch.omnet_phy._phase_noise.std = phase_noise_std_dB
+                        ch.pa_ramp_up_s = pa_ramp_up_s
+                        ch.pa_ramp_down_s = pa_ramp_down_s
+                        ch.pa_ramp_current_a = pa_ramp_current_a
+                        ch.antenna_model = antenna_model
+                        if hasattr(ch, "_phase_noise"):
+                            ch._phase_noise.std = phase_noise_std_dB
+                        if getattr(ch, "omnet_phy", None):
+                            ch.omnet_phy.clock_jitter_std_s = clock_jitter_std_s
+                            ch.omnet_phy.pa_ramp_up_s = pa_ramp_up_s
+                            ch.omnet_phy.pa_ramp_down_s = pa_ramp_down_s
+                            ch.omnet_phy.pa_ramp_current_a = pa_ramp_current_a
+                            ch.omnet_phy.antenna_model = antenna_model
+                            ch.omnet_phy._phase_noise.std = phase_noise_std_dB
                         ch_list.append(ch)
                     else:
                         ch_list.append(


### PR DESCRIPTION
## Summary
- avoid casting Channel objects to float when configuring simulator channels
- allow deterministic Oulu path loss by honoring shadowing_std

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890943ad7e883318774ea17562b96d2