### PR TITLE
Fix Oulu path loss randomness

### DIFF
--- a/simulateur_lora_sfrd/launcher/flora_phy.py
+++ b/simulateur_lora_sfrd/launcher/flora_phy.py
@@ -60,12 +60,9 @@ class FloraPHY:
                 + 10 * self.OULU_N * math.log10(d / self.OULU_D0)
                 - self.OULU_ANTENNA_GAIN
             )
-            sigma = (
-                self.channel.shadowing_std
-                if self.channel.shadowing_std > 0
-                else self.OULU_SIGMA
-            )
-            loss += random.gauss(0.0, sigma)
+            sigma = self.channel.shadowing_std
+            if sigma > 0:
+                loss += random.gauss(0.0, sigma)
         elif self.loss_model == "hata":
             loss = self.HATA_K1 + self.HATA_K2 * math.log10(d / 1000.0)
             if self.channel.shadowing_std > 0:


### PR DESCRIPTION
## Summary
- ensure Oulu path loss model respects channel shadowing_std and avoids randomization when set to 0

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689096f989a0833193736577f9b76331