### PR TITLE
Relax ADR1 degraded channel for higher PDR

### DIFF
--- a/simulateur_lora_sfrd/launcher/adr_standard_1.py
+++ b/simulateur_lora_sfrd/launcher/adr_standard_1.py
@@ -14,17 +14,17 @@ from .lorawan import TX_POWER_INDEX_TO_DBM
 DEGRADE_PARAMS = {
     "propagation_model": "cost231",
     "fading": "rayleigh",
-    # Reduced attenuation to ease channel conditions during validation
-    # Lighter degradation to improve packet delivery ratio
-    "path_loss_exp": 7.5,
-    "shadowing_std": 10.0,
-    "variable_noise_std": 1000.0,
-    "fine_fading_std": 400.0,
-    "freq_offset_std_hz": 300000.0,
-    "sync_offset_std_s": 1.5,
+    # Further lighten degradation to improve packet delivery ratio during
+    # validation runs
+    "path_loss_exp": 6.5,
+    "shadowing_std": 8.0,
+    "variable_noise_std": 500.0,
+    "fine_fading_std": 300.0,
+    "freq_offset_std_hz": 200000.0,
+    "sync_offset_std_s": 1.0,
     "advanced_capture": True,
-    "detection_threshold_dBm": -95.0,
-    "capture_threshold_dB": 12.0,
+    "detection_threshold_dBm": -92.0,
+    "capture_threshold_dB": 10.0,
 }
 
 


### PR DESCRIPTION
## Summary
- lighten degraded channel parameters for `adr_standard_1` to improve PDR during validation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891cb739448833188b807774feb2fef