### PR TITLE
Require RNG for LoRaPHY transmissions

### DIFF
--- a/simulateur_lora_sfrd/phy.py
+++ b/simulateur_lora_sfrd/phy.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import random
 import numpy as np
 
 from .loranode import Node
@@ -52,8 +51,12 @@ class LoRaPHY:
             freq_offset_hz=self.node.current_freq_offset,
             sync_offset_s=self.node.current_sync_offset,
         )
-        per = self.channel.packet_error_rate(snr, self.node.sf, payload_bytes=payload_size)
-        rand = rng.random() if rng is not None else random.random()
+        per = self.channel.packet_error_rate(
+            snr, self.node.sf, payload_bytes=payload_size
+        )
+        if rng is None:
+            raise ValueError("rng must be a numpy.random.Generator")
+        rand = rng.random()
         success = rand > per
         return rssi, snr, self.airtime(payload_size), success
 

--- a/tests/test_loraphy_requires_rng.py
+++ b/tests/test_loraphy_requires_rng.py
@@ -1,0 +1,32 @@
+import pytest
+from simulateur_lora_sfrd.phy import LoRaPHY
+from simulateur_lora_sfrd.loranode import Node
+from simulateur_lora_sfrd.launcher.channel import Channel
+
+def build_nodes():
+    ch1 = Channel(
+        shadowing_std=0.0,
+        fast_fading_std=0.0,
+        noise_floor_std=0.0,
+        pa_non_linearity_dB=0.0,
+        pa_non_linearity_std_dB=0.0,
+        frontend_filter_order=0,
+    )
+    ch2 = Channel(
+        shadowing_std=0.0,
+        fast_fading_std=0.0,
+        noise_floor_std=0.0,
+        pa_non_linearity_dB=0.0,
+        pa_non_linearity_std_dB=0.0,
+        frontend_filter_order=0,
+    )
+    n1 = Node(0, 0, 0, 7, 14, channel=ch1)
+    n2 = Node(1, 0, 0, 7, 14, channel=ch2)
+    return n1, n2
+
+
+def test_transmit_requires_rng():
+    src, dest = build_nodes()
+    phy = LoRaPHY(src)
+    with pytest.raises(ValueError):
+        phy.transmit(dest, 20)


### PR DESCRIPTION
## Summary
- enforce providing numpy RNG to LoRaPHY.transmit and remove fallback to Python's random
- add regression test ensuring transmit raises when RNG missing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891ff9636988331860611fecee1f318