### PR TITLE
Restore light channel degradation and fix dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Changed
-- Removed channel degradation in `adr_standard_1` for simulator validation.
+- Reintroduced a light channel degradation in `adr_standard_1` for simulator validation.
 - Send interval distribution now follows a strict exponential law and timestamps are only postponed when a transmission is still ongoing.
 
 ## [5.0] - 2025-07-24

--- a/simulateur_lora_sfrd/launcher/adr_standard_1.py
+++ b/simulateur_lora_sfrd/launcher/adr_standard_1.py
@@ -3,9 +3,31 @@ from __future__ import annotations
 from .simulator import Simulator
 from . import server
 from .lorawan import TX_POWER_INDEX_TO_DBM
+from .advanced_channel import AdvancedChannel
 
 
-def apply(sim: Simulator) -> None:
+# ---------------------------------------------------------------------------
+# Light degradation parameters applied when ``degrade_channel`` is True.  The
+# values are intentionally mild so the simulator remains stable while still
+# exercising more realistic conditions during validation.
+# ---------------------------------------------------------------------------
+
+DEGRADE_PARAMS = {
+    "propagation_model": "cost231",
+    "fading": "rayleigh",
+    "path_loss_exp": 4.0,
+    "shadowing_std": 4.0,
+    "variable_noise_std": 100.0,
+    "fine_fading_std": 100.0,
+    "freq_offset_std_hz": 50000.0,
+    "sync_offset_std_s": 0.25,
+    "advanced_capture": True,
+    "detection_threshold_dBm": -100.0,
+    "capture_threshold_dB": 6.0,
+}
+
+
+def apply(sim: Simulator, *, degrade_channel: bool = False) -> None:
     """Configure ADR variant ``adr_standard_1`` (LoRaWAN defaults).
 
     Parameters
@@ -32,4 +54,20 @@ def apply(sim: Simulator) -> None:
         node.adr_ack_limit = 64
         node.adr_ack_delay = 32
 
+    if degrade_channel:
+        new_channels = []
+        for ch in sim.multichannel.channels:
+            params = dict(DEGRADE_PARAMS)
+            params["frequency_hz"] = ch.frequency_hz
+            if hasattr(ch, "bandwidth"):
+                params["bandwidth"] = ch.bandwidth
+            if hasattr(ch, "coding_rate"):
+                params["coding_rate"] = ch.coding_rate
+            adv = AdvancedChannel(**params)
+            new_channels.append(adv)
 
+        sim.multichannel.channels = new_channels
+        sim.channel = sim.multichannel.channels[0]
+        sim.network_server.channel = sim.channel
+        for node in sim.nodes:
+            node.channel = sim.multichannel.select_mask(getattr(node, "chmask", 0xFFFF))

--- a/simulateur_lora_sfrd/launcher/dashboard.py
+++ b/simulateur_lora_sfrd/launcher/dashboard.py
@@ -532,7 +532,10 @@ def select_adr(module, name: str) -> None:
     else:
         adr3_button.button_type = "primary"
     if sim is not None:
-        module.apply(sim)
+        if module is adr_standard_1:
+            module.apply(sim, degrade_channel=True)
+        else:
+            module.apply(sim)
 
 
 _update_adr_badge("ADR 1")
@@ -744,7 +747,10 @@ def setup_simulation(seed_offset: int = 0):
 
     # Appliquer le profil ADR sélectionné
     if selected_adr_module:
-        selected_adr_module.apply(sim)
+        if selected_adr_module is adr_standard_1:
+            selected_adr_module.apply(sim, degrade_channel=True)
+        else:
+            selected_adr_module.apply(sim)
 
     # La mobilité est désormais gérée directement par le simulateur
     start_time = time.time()

--- a/tests/test_degraded_channel_interval.py
+++ b/tests/test_degraded_channel_interval.py
@@ -1,0 +1,57 @@
+from simulateur_lora_sfrd.launcher.simulator import Simulator
+from simulateur_lora_sfrd.launcher.adr_standard_1 import apply as apply_adr
+from simulateur_lora_sfrd.launcher.channel import Channel
+from simulateur_lora_sfrd.launcher.multichannel import MultiChannel
+
+
+def test_interval_with_degraded_channel():
+    mean_interval = 2.0
+    packets = 1000
+    sim = Simulator(
+        num_nodes=1,
+        num_gateways=1,
+        transmission_mode="Random",
+        packet_interval=mean_interval,
+        packets_to_send=packets,
+        pure_poisson_mode=True,
+        mobility=False,
+        seed=1,
+    )
+    apply_adr(sim, degrade_channel=True)
+    sim.run()
+    node = sim.nodes[0]
+    average = node._last_arrival_time / node.packets_sent
+    assert node.packets_sent == packets
+    assert abs(average - mean_interval) / mean_interval < 0.02
+
+
+def test_channels_identical_after_degrade():
+    channels = [
+        Channel(frequency_hz=868.1e6),
+        Channel(frequency_hz=868.3e6),
+        Channel(frequency_hz=868.5e6),
+    ]
+    multi = MultiChannel(channels)
+    sim = Simulator(
+        num_nodes=1,
+        num_gateways=1,
+        transmission_mode="Random",
+        packet_interval=1.0,
+        packets_to_send=1,
+        pure_poisson_mode=True,
+        mobility=False,
+        channels=multi,
+        seed=1,
+    )
+    apply_adr(sim, degrade_channel=True)
+
+    attrs = [
+        "path_loss_exp",
+        "shadowing_std",
+        "detection_threshold_dBm",
+        "capture_threshold_dB",
+    ]
+    reference = sim.multichannel.channels[0]
+    for ch in sim.multichannel.channels[1:]:
+        for attr in attrs:
+            assert getattr(ch, attr) == getattr(reference, attr)


### PR DESCRIPTION
## Summary
- restore optional light channel degradation in ADR 1
- make dashboard apply the degraded channel for ADR 1 profiles
- add regression tests for degraded channel behavior

## Testing
- `pytest tests/test_degraded_channel_interval.py tests/test_dashboard_pause.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68927e3e355483318f4f9a2bb791d7ee