### PR TITLE
Fix metric averaging to include all numeric values

### DIFF
--- a/simulateur_lora_sfrd/launcher/tests/test_dashboard_average_metrics.py
+++ b/simulateur_lora_sfrd/launcher/tests/test_dashboard_average_metrics.py
@@ -1,0 +1,19 @@
+import pytest
+
+panel = pytest.importorskip("panel")
+dashboard = pytest.importorskip("simulateur_lora_sfrd.launcher.dashboard")
+
+
+def test_average_numeric_metrics_union_and_numeric_filtering():
+    metrics = [
+        {"a": 1, "b": 2, "d": "x"},
+        {"a": 3, "c": 4, "d": 5},
+        {"a": True, "b": 4, "c": "y"},
+    ]
+    assert dashboard.average_numeric_metrics(metrics) == {
+        "a": 2.0,
+        "b": 3.0,
+        "c": 4.0,
+        "d": 5.0,
+    }
+


### PR DESCRIPTION
## Summary
- ensure `average_numeric_metrics` aggregates metrics across the union of keys
- add regression test for metric averaging behavior

## Testing
- `pytest simulateur_lora_sfrd/launcher/tests/test_dashboard_average_metrics.py simulateur_lora_sfrd/launcher/tests/test_dashboard_validation.py -q` *(skipped: panel not available)*

------
https://chatgpt.com/codex/tasks/task_e_689291e027e08331bbfe4163bbd42fab