### PR TITLE
feat: track metrics during simulation

### DIFF
--- a/simulateur_lora_sfrd/launcher/dashboard.py
+++ b/simulateur_lora_sfrd/launcher/dashboard.py
@@ -53,6 +53,7 @@ total_runs = 1
 current_run = 0
 runs_events: list[pd.DataFrame] = []
 runs_metrics: list[dict] = []
+RUNS_METRICS_LIMIT = 1000  # Max number of metric snapshots to keep
 auto_fast_forward = False
 timeline_fig = go.Figure()
 last_event_index = 0
@@ -589,7 +590,7 @@ def periodic_chrono_update():
 
 # --- Callback étape de simulation ---
 def step_simulation():
-    global last_step_ts, latest_metrics
+    global last_step_ts, latest_metrics, runs_metrics
     if sim is None or not session_alive():
         if not session_alive():
             _cleanup_callbacks()
@@ -606,6 +607,9 @@ def step_simulation():
     cont = sim.step()
     metrics = sim.get_metrics()
     latest_metrics = metrics
+    runs_metrics.append(metrics)
+    if len(runs_metrics) > RUNS_METRICS_LIMIT:
+        del runs_metrics[:-RUNS_METRICS_LIMIT]
     pdr_indicator.value = metrics["PDR"]
     collisions_indicator.value = metrics["collisions"]
     energy_indicator.value = metrics["energy_J"]

--- a/tests/test_runs_metrics_limit.py
+++ b/tests/test_runs_metrics_limit.py
@@ -1,0 +1,49 @@
+import pytest
+
+# Skip test if dashboard or panel not available
+pn = pytest.importorskip("panel")
+from simulateur_lora_sfrd.launcher import dashboard
+
+class DummyIndicator:
+    def __init__(self):
+        self.value = 0
+
+class DummySim:
+    def __init__(self):
+        self.running = True
+        self.counter = 0
+    def step(self):
+        self.counter += 1
+        return True
+    def get_metrics(self):
+        return {
+            "PDR": self.counter,
+            "collisions": 0,
+            "energy_J": 0,
+            "avg_delay_s": 0,
+            "throughput_bps": 0,
+            "retransmissions": 0,
+        }
+
+
+def test_runs_metrics_capped(monkeypatch):
+    # Patch indicators
+    for name in [
+        "callback_interval_indicator",
+        "pdr_indicator",
+        "collisions_indicator",
+        "energy_indicator",
+        "delay_indicator",
+        "throughput_indicator",
+        "retrans_indicator",
+    ]:
+        monkeypatch.setattr(dashboard, name, DummyIndicator())
+    # Patch session_alive to always return True
+    monkeypatch.setattr(dashboard, "session_alive", lambda: True)
+    # Set small limit for fast test
+    monkeypatch.setattr(dashboard, "RUNS_METRICS_LIMIT", 5, raising=False)
+    dashboard.runs_metrics.clear()
+    dashboard.sim = DummySim()
+    for _ in range(10):
+        dashboard.step_simulation()
+    assert len(dashboard.runs_metrics) == dashboard.RUNS_METRICS_LIMIT


### PR DESCRIPTION
## Summary
- collect metrics snapshots during each simulation step
- avoid unbounded growth of runs_metrics with a fixed-size buffer
- add unit test to ensure metrics list capping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6892fb5644e083318442a54108813c2b