### PR TITLE
Handle missing dashboard deps and warn on dead Bokeh session

### DIFF
--- a/panel/__init__.py
+++ b/panel/__init__.py
@@ -17,6 +17,7 @@ _repo_path = sys.path.pop(0)
 try:  # pragma: no cover - executed only when Panel is installed
     _panel = importlib.import_module("panel")
     import pandas  # noqa: F401  -- Panel requires pandas
+    import plotly  # noqa: F401  -- dashboard relies on Plotly
 except Exception as exc:  # pragma: no cover - when Panel or deps are missing
     raise ImportError("panel is not available in this test environment") from exc
 finally:

--- a/simulateur_lora_sfrd/launcher/dashboard.py
+++ b/simulateur_lora_sfrd/launcher/dashboard.py
@@ -97,10 +97,18 @@ def average_numeric_metrics(metrics_list: list[dict]) -> dict:
     return averages
 
 def session_alive() -> bool:
-    """Return True if the Bokeh session is still active."""
+    """Return True if the Bokeh session is still active.
+
+    Logs a warning in the console when the session is missing so that
+    callback stoppages caused by a disconnected Bokeh server are visible
+    instead of failing silently.
+    """
     doc = pn.state.curdoc
     sc = getattr(doc, "session_context", None)
-    return bool(sc and getattr(sc, "session", None))
+    alive = bool(sc and getattr(sc, "session", None))
+    if not alive:
+        print("⚠️ Bokeh session inactive")
+    return alive
 
 def _cleanup_callbacks() -> None:
     """Stop all periodic callbacks safely."""


### PR DESCRIPTION
## Summary
- require Plotly alongside Panel/pandas in panel stub
- warn in dashboard when Bokeh session is inactive so callbacks aren't silenced

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892fc2f769c833199895ca16a5a4c25