### PR TITLE
Retirer délais et retransmissions du dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,7 +753,7 @@ vise à faciliter les contributions extérieures.
 Les points suivants ont été intégrés au simulateur :
 
 - **PDR par nœud et par type de trafic.** Chaque nœud maintient l'historique de ses vingt dernières transmissions afin de calculer un taux de livraison global et récent. Ces valeurs sont visibles dans le tableau de bord et exportées dans un fichier `metrics_*.csv`.
-- **Historique glissant et indicateurs QoS.** Le simulateur calcule désormais le délai moyen de livraison ainsi que le nombre de retransmissions sur la période récente.
+- **Historique glissant et indicateurs QoS.** Le simulateur maintient un historique des transmissions pour calculer divers indicateurs de qualité de service.
 - **Indicateurs supplémentaires.** La méthode `get_metrics()` retourne le PDR par SF, passerelle, classe et nœud. Le tableau de bord affiche un récapitulatif et l'export produit deux fichiers CSV : un pour les événements détaillés et un pour les métriques agrégées.
  - **Moteur d'événements précis.** La file de priorité gère désormais un délai réseau de 10 ms et un traitement serveur de 1,2 s, reproduisant ainsi fidèlement l'ordonnancement d'OMNeT++.
 - **Suivi détaillé des ACK.** Chaque nœud mémorise les confirmations reçues pour appliquer fidèlement la logique ADR de FLoRa.

--- a/simulateur_lora_sfrd/launcher/dashboard.py
+++ b/simulateur_lora_sfrd/launcher/dashboard.py
@@ -268,7 +268,6 @@ collisions_indicator = pn.indicators.Number(
     name="Collisions", value=0.0, format="{value:.1f}"
 )
 energy_indicator = pn.indicators.Number(name="Énergie Tx (J)", value=0.0, format="{value:.3f}")
-delay_indicator = pn.indicators.Number(name="Délai moyen (s)", value=0.0, format="{value:.3f}")
 throughput_indicator = pn.indicators.Number(name="Débit (bps)", value=0.0, format="{value:.2f}")
 
 # Surveiller la fréquence réelle d'exécution du callback principal
@@ -276,11 +275,6 @@ callback_interval_indicator = pn.indicators.Number(
     name="Δt callback (ms)", value=0.0, format="{value:.0f}"
 )
 
-# Indicateur de retransmissions
-# Same for retransmissions which may also be averaged across runs
-retrans_indicator = pn.indicators.Number(
-    name="Retransmissions", value=0.0, format="{value:.1f}"
-)
 
 # Barre de progression pour l'accélération
 fast_forward_progress = pn.indicators.Progress(name="Avancement", value=0, width=200, visible=False)
@@ -621,9 +615,7 @@ def step_simulation():
     pdr_indicator.value = metrics["PDR"]
     collisions_indicator.value = metrics["collisions"]
     energy_indicator.value = metrics["energy_J"]
-    delay_indicator.value = metrics["avg_delay_s"]
     throughput_indicator.value = metrics["throughput_bps"]
-    retrans_indicator.value = metrics["retransmissions"]
 
     # Les traitements coûteux (construction des tableaux) sont délégués
     # à un callback dédié pour ne pas ralentir la boucle principale.
@@ -839,7 +831,6 @@ def setup_simulation(seed_offset: int = 0):
     pdr_indicator.value = 0
     collisions_indicator.value = 0
     energy_indicator.value = 0
-    delay_indicator.value = 0
     callback_interval_indicator.value = 0
     chrono_indicator.value = 0
     global node_paths
@@ -973,9 +964,7 @@ def on_stop(event):
             pdr_indicator.value = avg.get("PDR", 0.0)
             collisions_indicator.value = avg.get("collisions", 0)
             energy_indicator.value = avg.get("energy_J", 0.0)
-            delay_indicator.value = avg.get("avg_delay_s", 0.0)
             throughput_indicator.value = avg.get("throughput_bps", 0.0)
-            retrans_indicator.value = avg.get("retransmissions", 0)
             # PDR détaillés disponibles dans le fichier exporté uniquement
         current_run += 1
         seed_offset = current_run - 1
@@ -1032,9 +1021,7 @@ def on_stop(event):
         pdr_indicator.value = avg.get("PDR", 0.0)
         collisions_indicator.value = avg.get("collisions", 0)
         energy_indicator.value = avg.get("energy_J", 0.0)
-        delay_indicator.value = avg.get("avg_delay_s", 0.0)
         throughput_indicator.value = avg.get("throughput_bps", 0.0)
-        retrans_indicator.value = avg.get("retransmissions", 0)
         last = runs_metrics[-1]
         table_df = pd.DataFrame(
             {
@@ -1185,9 +1172,7 @@ def fast_forward(event=None):
                 pdr_indicator.value = metrics["PDR"]
                 collisions_indicator.value = metrics["collisions"]
                 energy_indicator.value = metrics["energy_J"]
-                delay_indicator.value = metrics["avg_delay_s"]
                 throughput_indicator.value = metrics["throughput_bps"]
-                retrans_indicator.value = metrics["retransmissions"]
                 global latest_metrics
                 latest_metrics = metrics
                 update_metrics_tables()
@@ -1393,10 +1378,8 @@ metrics_col = pn.Column(
     pdr_indicator,
     collisions_indicator,
     energy_indicator,
-    delay_indicator,
     throughput_indicator,
     callback_interval_indicator,
-    retrans_indicator,
     pdr_table,
     flora_compare_table,
 )

--- a/tests/test_runs_metrics_limit.py
+++ b/tests/test_runs_metrics_limit.py
@@ -33,9 +33,7 @@ def test_runs_metrics_capped(monkeypatch):
         "pdr_indicator",
         "collisions_indicator",
         "energy_indicator",
-        "delay_indicator",
         "throughput_indicator",
-        "retrans_indicator",
     ]:
         monkeypatch.setattr(dashboard, name, DummyIndicator())
     # Patch session_alive to always return True


### PR DESCRIPTION
## Summary
- remove average delay and retransmission indicators from dashboard
- update tests and documentation accordingly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893019db1c483318551fd0fe7148f53