### PR TITLE
Allow integer intervals and future-proof dashboard tests

### DIFF
--- a/simulateur_lora_sfrd/run.py
+++ b/simulateur_lora_sfrd/run.py
@@ -56,14 +56,12 @@ def simulate(
         raise ValueError("gateways must be >= 1")
     if channels < 1:
         raise ValueError("channels must be >= 1")
-    if not isinstance(interval, numbers.Real) or isinstance(interval, numbers.Integral) or interval <= 0:
-        raise ValueError("mean_interval must be positive float")
+    if not isinstance(interval, numbers.Real) or interval <= 0:
+        raise ValueError("interval must be positive real number")
     if first_interval is not None and (
-        not isinstance(first_interval, numbers.Real)
-        or isinstance(first_interval, numbers.Integral)
-        or first_interval <= 0
+        not isinstance(first_interval, numbers.Real) or first_interval <= 0
     ):
-        raise ValueError("first_interval must be positive float")
+        raise ValueError("first_interval must be positive real number")
     if steps <= 0:
         raise ValueError("steps must be > 0")
 

--- a/tests/test_compare_flora.py
+++ b/tests/test_compare_flora.py
@@ -8,9 +8,14 @@ from simulateur_lora_sfrd.launcher.compare_flora import (
     load_flora_rx_stats,
 )
 
+pytest.importorskip(
+    "pandas",
+    reason="pandas is required to parse FLoRa metrics",
+    exc_type=ImportError,
+)
+
 
 def test_compare_with_flora(tmp_path):
-    pytest.importorskip('pandas')
     data_path = Path(__file__).parent / 'data' / 'flora_metrics.csv'
     flora_copy = tmp_path / 'flora_metrics.csv'
     flora_copy.write_bytes(data_path.read_bytes())
@@ -32,7 +37,6 @@ def test_compare_with_flora(tmp_path):
 
 def test_load_flora_metrics_from_sca(tmp_path):
     """Metrics should be correctly parsed from a single .sca file."""
-    pytest.importorskip('pandas')
     sca = tmp_path / "metrics.sca"
     sca.write_text("""\
 scalar sim sent 10
@@ -48,7 +52,6 @@ scalar sim sf8 3
 
 def test_load_flora_metrics_directory(tmp_path):
     """Aggregated metrics from a directory of .sca files are combined."""
-    pytest.importorskip('pandas')
     sca1 = tmp_path / "run1.sca"
     sca1.write_text("""\
 scalar sim sent 5
@@ -71,7 +74,6 @@ scalar sim sf8 3
 
 def test_compare_with_flora_mismatch(tmp_path):
     """Comparison should fail when metrics differ significantly."""
-    pytest.importorskip('pandas')
     data_path = Path(__file__).parent / 'data' / 'flora_metrics.csv'
     flora_copy = tmp_path / 'flora_metrics.csv'
     flora_copy.write_bytes(data_path.read_bytes())
@@ -82,7 +84,6 @@ def test_compare_with_flora_mismatch(tmp_path):
 
 def test_rssi_snr_match(tmp_path):
     """Parsed RSSI/SNR values should match simulator results."""
-    pytest.importorskip('pandas')
     sim = Simulator(
         num_nodes=1,
         num_gateways=1,
@@ -108,7 +109,6 @@ def test_rssi_snr_match(tmp_path):
 
 def test_energy_consumption_match(tmp_path):
     """Total energy parsed from a .sca file should match simulator metrics."""
-    pytest.importorskip('pandas')
     sim = Simulator(
         num_nodes=1,
         num_gateways=1,
@@ -133,7 +133,6 @@ def test_energy_consumption_match(tmp_path):
 
 def test_average_delay_match(tmp_path):
     """Average delay parsed from a .sca file should match simulator metrics."""
-    pytest.importorskip('pandas')
     sim = Simulator(
         num_nodes=1,
         num_gateways=1,
@@ -158,7 +157,6 @@ def test_average_delay_match(tmp_path):
 
 def test_flora_full_mode(tmp_path):
     """PDR and SF distribution should match FLoRa within 1%."""
-    pytest.importorskip('pandas')
     data_path = Path(__file__).parent / 'data' / 'flora_metrics.csv'
     flora_copy = tmp_path / 'flora_metrics.csv'
     flora_copy.write_bytes(data_path.read_bytes())

--- a/tests/test_dashboard_pause.py
+++ b/tests/test_dashboard_pause.py
@@ -1,7 +1,10 @@
 import pytest
 
-
-dashboard = pytest.importorskip('simulateur_lora_sfrd.launcher.dashboard')
+dashboard = pytest.importorskip(
+    "simulateur_lora_sfrd.launcher.dashboard",
+    reason="dashboard dependencies not available",
+    exc_type=ImportError,
+)
 
 
 def test_pause_then_finish_resets_buttons():
@@ -28,3 +31,4 @@ def test_pause_then_finish_resets_buttons():
 
     # cleanup
     dashboard._cleanup_callbacks()
+

--- a/tests/test_exporter_csv.py
+++ b/tests/test_exporter_csv.py
@@ -1,7 +1,9 @@
 import subprocess
 import pytest
 
-pn = pytest.importorskip("panel")
+pn = pytest.importorskip(
+    "panel", reason="panel is required for dashboard tests", exc_type=ImportError
+)
 pd = pytest.importorskip("pandas")
 
 from simulateur_lora_sfrd.launcher import dashboard  # noqa: E402

--- a/tests/test_fast_forward_finished.py
+++ b/tests/test_fast_forward_finished.py
@@ -1,7 +1,9 @@
 import pytest
 
 from simulateur_lora_sfrd.launcher.simulator import Simulator
-pn = pytest.importorskip("panel")
+pn = pytest.importorskip(
+    "panel", reason="panel is required for dashboard tests", exc_type=ImportError
+)
 import simulateur_lora_sfrd.launcher.dashboard as dashboard  # noqa: E402
 
 

--- a/tests/test_flora_capture.py
+++ b/tests/test_flora_capture.py
@@ -7,7 +7,9 @@ from simulateur_lora_sfrd.launcher.compare_flora import load_flora_metrics
 
 
 def test_omnet_phy_flora_capture_matches_sca():
-    pytest.importorskip('pandas')
+    pytest.importorskip(
+        "pandas", reason="pandas is required for FLoRa capture", exc_type=ImportError
+    )
     ch = Channel(phy_model="omnet", flora_capture=True, shadowing_std=0.0, fast_fading_std=0.0)
     phy: OmnetPHY = ch.omnet_phy
     rssi_list = [-50.0, -55.0]

--- a/tests/test_flora_example.py
+++ b/tests/test_flora_example.py
@@ -7,7 +7,9 @@ from simulateur_lora_sfrd.launcher.compare_flora import compare_with_sim
 
 
 def test_flora_example_matches_flora():
-    pytest.importorskip('pandas')
+    pytest.importorskip(
+        "pandas", reason="pandas is required for flora example", exc_type=ImportError
+    )
     # Execute the example script as if run directly
     globals_dict = runpy.run_path('examples/run_flora_example.py', run_name='__main__')
     sim = globals_dict['sim']

--- a/tests/test_flora_sca.py
+++ b/tests/test_flora_sca.py
@@ -14,7 +14,9 @@ CONFIG = "flora-master/simulations/examples/n100-gw1.ini"
 
 @pytest.mark.slow
 def test_flora_sca_compare():
-    pytest.importorskip("pandas")
+    pytest.importorskip(
+        "pandas", reason="pandas is required for flora comparison", exc_type=ImportError
+    )
     sca = Path(__file__).parent / "data" / "n100_gw1_expected.sca"
     sim = Simulator(flora_mode=True, config_file=CONFIG, seed=1, adr_method="avg")
     adr1(sim)

--- a/tests/test_runs_metrics_limit.py
+++ b/tests/test_runs_metrics_limit.py
@@ -1,7 +1,9 @@
 import pytest
 
 # Skip test if dashboard or panel not available
-pn = pytest.importorskip("panel")
+pn = pytest.importorskip(
+    "panel", reason="panel is required for dashboard tests", exc_type=ImportError
+)
 from simulateur_lora_sfrd.launcher import dashboard
 
 class DummyIndicator:


### PR DESCRIPTION
## Summary
- accept integer `interval` values in the core simulator
- ensure dashboard and FLoRa comparison tests skip cleanly when pandas or panel are missing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689301d9d650833186963f4f1bd6502e