### PR TITLE
Handle region kw conflict in region_channels

### DIFF
--- a/simulateur_lora_sfrd/launcher/channel.py
+++ b/simulateur_lora_sfrd/launcher/channel.py
@@ -717,13 +717,20 @@ class Channel:
         cls.REGION_CHANNELS[name.upper()] = list(frequencies)
 
     @classmethod
-    def region_channels(cls, region: str, **kwargs) -> list["Channel"]:
+    def region_channels(cls, region_name: str, **kwargs) -> list["Channel"]:
         """Return a list of ``Channel`` objects for the given region preset."""
-        reg = region.upper()
+        reg = region_name.upper()
         if reg not in cls.REGION_CHANNELS:
-            raise ValueError(f"Unknown region preset: {region}")
-        return [cls(frequency_hz=f, region=reg, channel_index=i, **kwargs)
-                for i, f in enumerate(cls.REGION_CHANNELS[reg])]
+            raise ValueError(f"Unknown region preset: {region_name}")
+        # ``region`` may accidentally be passed in ``kwargs`` which would
+        # result in ``TypeError: multiple values for argument 'region'``.
+        # Remove it so our explicit ``reg`` always takes precedence.
+        kwargs = dict(kwargs)
+        kwargs.pop("region", None)
+        return [
+            cls(frequency_hz=f, region=reg, channel_index=i, **kwargs)
+            for i, f in enumerate(cls.REGION_CHANNELS[reg])
+        ]
 
     # ------------------------------------------------------------------
     # Sensitivity computation

--- a/tests/test_region_channels.py
+++ b/tests/test_region_channels.py
@@ -1,0 +1,7 @@
+from simulateur_lora_sfrd.launcher.channel import Channel
+
+
+def test_region_channels_accepts_region_in_kwargs():
+    channels = Channel.region_channels("EU868", region="ignored")
+    assert len(channels) == len(Channel.REGION_CHANNELS["EU868"])
+    assert all(ch.region == "EU868" for ch in channels)


### PR DESCRIPTION
## Summary
- Allow `Channel.region_channels` to safely handle a `region` keyword argument
- Add regression test for channel region helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893069154a88331b82a92a5791b8e28