### PR TITLE
Fix dashboard metrics update for Bokeh 3

### DIFF
--- a/simulateur_lora_sfrd/launcher/dashboard.py
+++ b/simulateur_lora_sfrd/launcher/dashboard.py
@@ -111,7 +111,19 @@ def session_alive() -> bool:
     """
     doc = pn.state.curdoc
     sc = getattr(doc, "session_context", None)
-    alive = bool(sc and getattr(sc, "session", None))
+    # ``session`` was removed in newer versions of Bokeh (>=3).  When running
+    # with such versions the original check evaluated to ``False`` even though
+    # the session was still alive, preventing periodic callbacks from running
+    # and leaving dashboard metrics stuck at their initial values.  Consider the
+    # session active if a session context exists and exposes either the legacy
+    # ``session`` attribute or the newer ``server_context`` attribute.
+    alive = bool(
+        sc
+        and (
+            getattr(sc, "session", None) is not None
+            or getattr(sc, "server_context", None) is not None
+        )
+    )
     if not alive:
         print("⚠️ Bokeh session inactive")
     return alive

--- a/tests/test_session_alive_bokeh3.py
+++ b/tests/test_session_alive_bokeh3.py
@@ -1,0 +1,25 @@
+import pytest
+
+# Skip the test gracefully if the dashboard (and its heavy dependencies like
+# Panel) are unavailable in the execution environment.
+dashboard = pytest.importorskip(
+    "simulateur_lora_sfrd.launcher.dashboard",
+    reason="dashboard dependencies not available",
+    exc_type=Exception,
+)
+
+
+class DummySessionContext:
+    def __init__(self):
+        # Simulates Bokeh >=3 where the ``session`` attribute is missing
+        # but ``server_context`` is still available for active sessions.
+        self.server_context = object()
+
+
+class DummyDoc:
+    session_context = DummySessionContext()
+
+
+def test_session_alive_with_server_context(monkeypatch):
+    monkeypatch.setattr(dashboard.pn.state, "curdoc", DummyDoc())
+    assert dashboard.session_alive() is True


### PR DESCRIPTION
## Summary
- ensure dashboard session detection works with Bokeh >=3 by accepting `server_context`
- cover Bokeh 3 session detection with a regression test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68930e20bbb08331bfe438dafcb7cabb