### PR TITLE
feat: add Aloha channel model option

### DIFF
--- a/simulateur_lora_sfrd/launcher/channel.py
+++ b/simulateur_lora_sfrd/launcher/channel.py
@@ -165,6 +165,7 @@ class Channel:
         region: str | None = None,
         channel_index: int = 0,
         orthogonal_sf: bool = True,
+        aloha_channel_model: bool = False,
         rng: np.random.Generator | None = None,
     ):
         """
@@ -257,6 +258,8 @@ class Channel:
             région choisie.
         :param orthogonal_sf: Si ``True``, les transmissions de SF différents
             n'interfèrent pas entre elles.
+        :param aloha_channel_model: Active un modèle de canal Aloha où toute
+            superposition provoque une collision immédiate (sans capture).
         :param flora_noise_path: Chemin vers ``flora_noise_table.json`` ou vers
             ``LoRaAnalogModel.cc`` pour charger la table de bruit FLoRa.
         :param sensitivity_mode: "flora" pour utiliser les valeurs de bruit
@@ -392,6 +395,7 @@ class Channel:
         self.capture_threshold_dB = capture_threshold_dB
         self.capture_window_symbols = int(capture_window_symbols)
         self.orthogonal_sf = orthogonal_sf
+        self.aloha_channel_model = bool(aloha_channel_model)
         self.last_rssi_dBm = 0.0
         self.last_noise_dBm = 0.0
         self.last_filter_att_dB = 0.0

--- a/simulateur_lora_sfrd/launcher/flora_cpp.py
+++ b/simulateur_lora_sfrd/launcher/flora_cpp.py
@@ -58,8 +58,12 @@ class FloraCppPHY:
         start_list: list[float],
         end_list: list[float],
         freq_list: list[float],
+        *,
+        aloha_channel_model: bool = False,
     ) -> list[bool]:
         length = len(rssi_list)
+        if aloha_channel_model and length > 1:
+            return [False] * length
         arr_type_d = ctypes.c_double * length
         arr_type_i = ctypes.c_int * length
         res = self.lib.flora_capture(

--- a/simulateur_lora_sfrd/launcher/flora_phy.py
+++ b/simulateur_lora_sfrd/launcher/flora_phy.py
@@ -87,6 +87,8 @@ class FloraPHY:
         start_list: list[float],
         end_list: list[float],
         freq_list: list[float],
+        *,
+        aloha_channel_model: bool = False,
     ) -> list[bool]:
         """Return the capture decision for each concurrent signal.
 
@@ -94,6 +96,8 @@ class FloraPHY:
         the strongest packet wins only if the power difference with each
         interferer is above the ``NON_ORTH_DELTA`` threshold *and* the
         interferer overlaps past the ``preamble - 6`` symbols window.
+        When ``aloha_channel_model`` is ``True`` the matrix check is skipped
+        and any overlap immediately causes a collision.
         """
 
         if not rssi_list:
@@ -127,6 +131,10 @@ class FloraPHY:
             overlap = min(end0, end_list[idx]) > max(start0, start_list[idx])
             if not overlap:
                 continue
+
+            if aloha_channel_model:
+                captured = False
+                break
 
             diff = rssi0 - rssi_list[idx]
             th = self.NON_ORTH_DELTA[sf0 - 7][sf_list[idx] - 7]

--- a/simulateur_lora_sfrd/launcher/gateway.py
+++ b/simulateur_lora_sfrd/launcher/gateway.py
@@ -63,6 +63,7 @@ class Gateway:
         capture_mode: str = "basic",
         flora_phy=None,
         orthogonal_sf: bool = True,
+        aloha_channel_model: bool = False,
         capture_window_symbols: int = 5,
     ):
         """
@@ -85,6 +86,8 @@ class Gateway:
             "flora".
         :param orthogonal_sf: Si ``True``, les transmissions de SF différents
             sont ignorées pour la détection de collision.
+        :param aloha_channel_model: Active un modèle Aloha avec collisions
+            immédiates (sans capture).
         :param capture_window_symbols: Nombre de symboles de préambule exigés
             avant qu'un paquet puisse capturer la réception (par défaut 5).
         """
@@ -209,7 +212,14 @@ class Gateway:
             start_list = [t['start_time'] for t in colliders]
             end_list = [t['end_time'] for t in colliders]
             freq_list = [t['frequency'] for t in colliders]
-            winners = flora_phy.capture(rssi_list, sf_list, start_list, end_list, freq_list)
+            winners = flora_phy.capture(
+                rssi_list,
+                sf_list,
+                start_list,
+                end_list,
+                freq_list,
+                aloha_channel_model=aloha_channel_model,
+            )
             capture = any(winners)
             if capture:
                 win_idx = winners.index(True)

--- a/simulateur_lora_sfrd/launcher/simulator.py
+++ b/simulateur_lora_sfrd/launcher/simulator.py
@@ -101,6 +101,7 @@ class Simulator:
         seed: int | None = None,
         class_c_rx_interval: float = 1.0,
         phy_model: str = "",
+        aloha_channel_model: bool = False,
         flora_loss_model: str = "lognorm",
         terrain_map: str | list[list[float]] | None = None,
         path_map: str | list[list[float]] | None = None,
@@ -176,6 +177,9 @@ class Simulator:
             downlink pour les nœuds de classe C (s).
         :param phy_model: "omnet" ou "flora" pour activer un modèle physique
             inspiré de FLoRa.
+        :param aloha_channel_model: Si ``True``, toute superposition de
+            transmissions entraîne une collision immédiate (modèle Aloha
+            comme dans FLoRa).
         :param flora_loss_model: Variante d'atténuation FLoRa ("lognorm",
             "oulu" ou "hata").
         :param terrain_map: Carte de terrain utilisée pour la mobilité
@@ -361,6 +365,7 @@ class Simulator:
                         phy_model=ch_phy_model,
                         environment=env,
                         flora_loss_model=flora_loss_model,
+                        aloha_channel_model=aloha_channel_model,
                         multipath_taps=3 if flora_mode else 1,
                         phase_noise_std_dB=phase_noise_std_dB,
                         clock_jitter_std_s=clock_jitter_std_s,
@@ -390,6 +395,7 @@ class Simulator:
                             ) = Channel.ENV_PRESETS["flora"]
                         if flora_mode and ch.multipath_taps <= 1:
                             ch.multipath_taps = 3
+                        ch.aloha_channel_model = aloha_channel_model
                         ch.phase_noise_std_dB = phase_noise_std_dB
                         ch.clock_jitter_std_s = clock_jitter_std_s
                         ch.pa_ramp_up_s = pa_ramp_up_s
@@ -418,6 +424,7 @@ class Simulator:
                                     else None
                                 ),
                                 flora_loss_model=flora_loss_model,
+                                aloha_channel_model=aloha_channel_model,
                                 multipath_taps=3 if flora_mode else 1,
                                 phase_noise_std_dB=phase_noise_std_dB,
                                 clock_jitter_std_s=clock_jitter_std_s,
@@ -877,6 +884,7 @@ class Simulator:
                         else None
                     ),
                     orthogonal_sf=node.channel.orthogonal_sf,
+                    aloha_channel_model=node.channel.aloha_channel_model,
                     capture_window_symbols=node.channel.capture_window_symbols,  # default: 6
                 )
 

--- a/simulateur_lora_sfrd/run.py
+++ b/simulateur_lora_sfrd/run.py
@@ -37,6 +37,7 @@ def simulate(
     noise_std=0.0,
     debug_rx=False,
     phy_model="omnet",
+    aloha_channel_model: bool = False,
     voltage=3.3,
     tx_current=0.06,
     rx_current=0.011,
@@ -84,6 +85,7 @@ def simulate(
         rx_current_a=rx_current,
         idle_current_a=idle_current,
         voltage_v=voltage,
+        aloha_channel_model=aloha_channel_model,
     )
     airtime = channel.airtime(7, payload_size=PAYLOAD_SIZE)
     tx_energy = (tx_current - idle_current) * voltage * airtime
@@ -310,6 +312,11 @@ def main(argv=None):
         help="Modèle physique à utiliser (omnet, flora ou flora_cpp)",
     )
     parser.add_argument(
+        "--aloha-channel",
+        action="store_true",
+        help="Utilise le modèle de canal Aloha (collisions immédiates)",
+    )
+    parser.add_argument(
         "--voltage",
         type=float,
         default=3.3,
@@ -400,6 +407,7 @@ def main(argv=None):
             rx_current=args.rx_current,
             idle_current=args.idle_current,
             rng_manager=rng_manager,
+            aloha_channel_model=args.aloha_channel,
         )
         results.append((delivered, collisions, pdr, energy, avg_delay, throughput))
         logging.info(


### PR DESCRIPTION
## Summary
- allow `aloha_channel_model` parameter on `Channel` with propagation through `Simulator` and `Gateway`
- skip NON_ORTH_DELTA capture when using Aloha model in `FloraPHY`
- expose `--aloha-channel` CLI flag for FLoRa-compatible behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68930e42812c8331b4f17c7669f23d11