### PR TITLE
Enable Aloha channel model by default

### DIFF
--- a/simulateur_lora_sfrd/launcher/channel.py
+++ b/simulateur_lora_sfrd/launcher/channel.py
@@ -165,7 +165,7 @@ class Channel:
         region: str | None = None,
         channel_index: int = 0,
         orthogonal_sf: bool = True,
-        aloha_channel_model: bool = False,
+        aloha_channel_model: bool = True,
         rng: np.random.Generator | None = None,
     ):
         """

--- a/simulateur_lora_sfrd/launcher/flora_cpp.py
+++ b/simulateur_lora_sfrd/launcher/flora_cpp.py
@@ -59,7 +59,7 @@ class FloraCppPHY:
         end_list: list[float],
         freq_list: list[float],
         *,
-        aloha_channel_model: bool = False,
+        aloha_channel_model: bool = True,
     ) -> list[bool]:
         length = len(rssi_list)
         if aloha_channel_model and length > 1:

--- a/simulateur_lora_sfrd/launcher/flora_phy.py
+++ b/simulateur_lora_sfrd/launcher/flora_phy.py
@@ -88,7 +88,7 @@ class FloraPHY:
         end_list: list[float],
         freq_list: list[float],
         *,
-        aloha_channel_model: bool = False,
+        aloha_channel_model: bool = True,
     ) -> list[bool]:
         """Return the capture decision for each concurrent signal.
 

--- a/simulateur_lora_sfrd/launcher/gateway.py
+++ b/simulateur_lora_sfrd/launcher/gateway.py
@@ -63,7 +63,7 @@ class Gateway:
         capture_mode: str = "basic",
         flora_phy=None,
         orthogonal_sf: bool = True,
-        aloha_channel_model: bool = False,
+        aloha_channel_model: bool = True,
         capture_window_symbols: int = 5,
     ):
         """

--- a/simulateur_lora_sfrd/launcher/simulator.py
+++ b/simulateur_lora_sfrd/launcher/simulator.py
@@ -101,7 +101,7 @@ class Simulator:
         seed: int | None = None,
         class_c_rx_interval: float = 1.0,
         phy_model: str = "",
-        aloha_channel_model: bool = False,
+        aloha_channel_model: bool = True,
         flora_loss_model: str = "lognorm",
         terrain_map: str | list[list[float]] | None = None,
         path_map: str | list[list[float]] | None = None,

--- a/simulateur_lora_sfrd/run.py
+++ b/simulateur_lora_sfrd/run.py
@@ -37,7 +37,7 @@ def simulate(
     noise_std=0.0,
     debug_rx=False,
     phy_model="omnet",
-    aloha_channel_model: bool = False,
+    aloha_channel_model: bool = True,
     voltage=3.3,
     tx_current=0.06,
     rx_current=0.011,
@@ -313,7 +313,8 @@ def main(argv=None):
     )
     parser.add_argument(
         "--aloha-channel",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
+        default=True,
         help="Utilise le modèle de canal Aloha (collisions immédiates)",
     )
     parser.add_argument(

--- a/tests/test_collision_capture.py
+++ b/tests/test_collision_capture.py
@@ -12,8 +12,8 @@ def _setup():
 def test_same_sf_collision():
     gw, server = _setup()
     # two transmissions start at the same time with same SF/frequency
-    gw.start_reception(1, 1, 7, -50, 0.1, 6.0, 0.0, 868e6)
-    gw.start_reception(2, 2, 7, -58, 0.1, 6.0, 0.0, 868e6)
+    gw.start_reception(1, 1, 7, -50, 0.1, 6.0, 0.0, 868e6, aloha_channel_model=False)
+    gw.start_reception(2, 2, 7, -58, 0.1, 6.0, 0.0, 868e6, aloha_channel_model=False)
     gw.end_reception(1, server, 1)
     gw.end_reception(2, server, 2)
     assert server.packets_received == 0
@@ -24,8 +24,8 @@ def test_capture_after_five_preamble():
     sf = 7
     symbol_time = (2 ** sf) / 125e3
     start2 = 5.1 * symbol_time
-    gw.start_reception(1, 1, sf, -50, 0.1, 6.0, 0.0, 868e6)
-    gw.start_reception(2, 2, sf, -60, 0.1, 6.0, start2, 868e6)
+    gw.start_reception(1, 1, sf, -50, 0.1, 6.0, 0.0, 868e6, aloha_channel_model=False)
+    gw.start_reception(2, 2, sf, -60, 0.1, 6.0, start2, 868e6, aloha_channel_model=False)
     gw.end_reception(1, server, 1)
     gw.end_reception(2, server, 2)
     assert server.packets_received == 1

--- a/tests/test_gateway_capture.py
+++ b/tests/test_gateway_capture.py
@@ -8,10 +8,10 @@ def test_orthogonal_sf_no_collision():
     server.gateways = [gw]
 
     gw.start_reception(
-        1, 1, 7, -60, 1.0, 6.0, 0.0, 868e6, orthogonal_sf=True
+        1, 1, 7, -60, 1.0, 6.0, 0.0, 868e6, orthogonal_sf=True, aloha_channel_model=False
     )
     gw.start_reception(
-        2, 2, 9, -60, 1.0, 6.0, 0.0, 868e6, orthogonal_sf=True
+        2, 2, 9, -60, 1.0, 6.0, 0.0, 868e6, orthogonal_sf=True, aloha_channel_model=False
     )
     gw.end_reception(1, server, 1)
     gw.end_reception(2, server, 2)
@@ -25,9 +25,9 @@ def test_capture_requires_five_symbols():
     server.gateways = [gw]
 
     # Strong signal starts first
-    gw.start_reception(1, 1, 7, -50, 1.0, 6.0, 0.0, 868e6)
+    gw.start_reception(1, 1, 7, -50, 1.0, 6.0, 0.0, 868e6, aloha_channel_model=False)
     # Weaker packet starts after more than 5 symbols
-    gw.start_reception(2, 2, 7, -60, 1.0, 6.0, 0.006, 868e6)
+    gw.start_reception(2, 2, 7, -60, 1.0, 6.0, 0.006, 868e6, aloha_channel_model=False)
     gw.end_reception(1, server, 1)
     gw.end_reception(2, server, 2)
 
@@ -40,8 +40,8 @@ def test_no_capture_before_five_symbols():
     server.gateways = [gw]
 
     # Strong signal starts first but second arrives too soon
-    gw.start_reception(1, 1, 7, -50, 1.0, 6.0, 0.0, 868e6)
-    gw.start_reception(2, 2, 7, -60, 1.0, 6.0, 0.003, 868e6)
+    gw.start_reception(1, 1, 7, -50, 1.0, 6.0, 0.0, 868e6, aloha_channel_model=False)
+    gw.start_reception(2, 2, 7, -60, 1.0, 6.0, 0.003, 868e6, aloha_channel_model=False)
     gw.end_reception(1, server, 1)
     gw.end_reception(2, server, 2)
 
@@ -54,9 +54,9 @@ def test_strong_signal_arrives_late():
     server.gateways = [gw]
 
     # Weak packet first
-    gw.start_reception(1, 1, 7, -60, 1.0, 6.0, 0.0, 868e6)
+    gw.start_reception(1, 1, 7, -60, 1.0, 6.0, 0.0, 868e6, aloha_channel_model=False)
     # Strong packet after 5 symbols should not capture
-    gw.start_reception(2, 2, 7, -50, 1.0, 6.0, 0.006, 868e6)
+    gw.start_reception(2, 2, 7, -50, 1.0, 6.0, 0.006, 868e6, aloha_channel_model=False)
     gw.end_reception(1, server, 1)
     gw.end_reception(2, server, 2)
 
@@ -69,8 +69,30 @@ def test_cross_sf_collision():
     server.gateways = [gw]
 
     # Two packets on the same frequency with different SF collide
-    gw.start_reception(1, 1, 7, -60, 1.0, 6.0, 0.0, 868e6, orthogonal_sf=False)
-    gw.start_reception(2, 2, 9, -60, 1.0, 6.0, 0.0, 868e6, orthogonal_sf=False)
+    gw.start_reception(
+        1,
+        1,
+        7,
+        -60,
+        1.0,
+        6.0,
+        0.0,
+        868e6,
+        orthogonal_sf=False,
+        aloha_channel_model=False,
+    )
+    gw.start_reception(
+        2,
+        2,
+        9,
+        -60,
+        1.0,
+        6.0,
+        0.0,
+        868e6,
+        orthogonal_sf=False,
+        aloha_channel_model=False,
+    )
     gw.end_reception(1, server, 1)
     gw.end_reception(2, server, 2)
 
@@ -83,9 +105,31 @@ def test_cross_sf_capture_after_delay():
     server.gateways = [gw]
 
     # Strong signal starts first and should capture the weaker one
-    gw.start_reception(1, 1, 7, -50, 1.0, 6.0, 0.0, 868e6, orthogonal_sf=False)
+    gw.start_reception(
+        1,
+        1,
+        7,
+        -50,
+        1.0,
+        6.0,
+        0.0,
+        868e6,
+        orthogonal_sf=False,
+        aloha_channel_model=False,
+    )
     # Weaker packet with higher SF starts after more than 5 of its symbols
-    gw.start_reception(2, 2, 9, -60, 1.0, 6.0, 0.03, 868e6, orthogonal_sf=False)
+    gw.start_reception(
+        2,
+        2,
+        9,
+        -60,
+        1.0,
+        6.0,
+        0.03,
+        868e6,
+        orthogonal_sf=False,
+        aloha_channel_model=False,
+    )
     gw.end_reception(1, server, 1)
     gw.end_reception(2, server, 2)
 


### PR DESCRIPTION
## Summary
- enable the Aloha channel model by default across the simulator stack
- allow CLI users to disable it with `--no-aloha-channel`
- adjust tests to explicitly disable Aloha when validating capture scenarios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893125c86688331a6f8581dc16921db