### PR TITLE
Include pydantic dependency for dashboard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   "plotly>=5.4",
   "panel>=0.13",
   "fastapi>=0.88",
+  "pydantic>=1.10",
   "uvicorn>=0.20"
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ matplotlib>=3.5
 plotly>=5.4
 panel>=0.13
 fastapi>=0.88
+pydantic>=1.10
 uvicorn>=0.20


### PR DESCRIPTION
## Summary
- ensure pydantic is installed before launching the dashboard
- keep pyproject dependencies in sync with requirements

## Testing
- `pytest >/tmp/unit.log && tail -n 20 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_689312e77760833196dd8e4cceb19614