### PR TITLE
Handle missing FLoRa native library gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,9 +592,11 @@ make -j$(nproc)
 Pour interfacer le simulateur Python avec la couche physique C++ et calculer la
 BER exacte via ``ctypes``, la bibliothèque partagée ``libflora_phy.so`` est
 désormais compilée automatiquement lors de l'installation (`pip install -e .`).
-Si besoin, vous pouvez toujours lancer manuellement `./scripts/build_flora_cpp.sh`
-depuis la racine du dépôt pour régénérer la bibliothèque.  Le fichier généré est
-automatiquement détecté par ``FloraPHY`` pour calculer la BER.
+Si elle est absente, ``FloraPHY`` bascule automatiquement sur une implémentation
+Python (plus lente mais fonctionnelle) et émet un avertissement.  Vous pouvez
+toujours lancer manuellement `./scripts/build_flora_cpp.sh` depuis la racine du
+dépôt pour régénérer la bibliothèque ; le fichier généré est détecté
+automatiquement par ``FloraPHY``.
 
 Placez ce fichier à la racine du projet ou dans ``flora-master`` puis lancez le
 simulateur avec ``phy_model="flora_cpp"`` pour utiliser ces routines natives.

--- a/simulateur_lora_sfrd/launcher/flora_phy.py
+++ b/simulateur_lora_sfrd/launcher/flora_phy.py
@@ -44,14 +44,21 @@ class FloraPHY:
         self._cpp = None
         if self.use_exact_ber:
             from .flora_cpp import FloraCppPHY
-
             try:
                 self._cpp = FloraCppPHY()
             except OSError as exc:
-                raise OSError(
-                    "libflora_phy.so introuvable. "
-                    "Installez le paquet pour compiler automatiquement la bibliothèque"
-                ) from exc
+                import warnings
+
+                warnings.warn(
+                    (
+                        "libflora_phy.so introuvable. "
+                        "Utilisation de l'implémentation Python, "
+                        "ce qui peut ralentir la simulation. "
+                        "Installez le paquet pour compiler automatiquement la bibliothèque"
+                    ),
+                    RuntimeWarning,
+                )
+                self._cpp = None
 
     def path_loss(self, distance: float) -> float:
         if distance <= 0:


### PR DESCRIPTION
## Summary
- fall back to Python PER/BER calculations when libflora_phy.so is absent and warn the user
- document the automatic Python fallback in README

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893e33db3d483318a31e0d63192a29a