### PR TITLE
Fix SF distribution graph categories

### DIFF
--- a/simulateur_lora_sfrd/launcher/dashboard.py
+++ b/simulateur_lora_sfrd/launcher/dashboard.py
@@ -475,7 +475,9 @@ def update_histogram(metrics: dict | None = None) -> None:
         metrics = sim.get_metrics()
     if hist_metric_select.value == "SF":
         sf_dist = metrics["sf_distribution"]
-        fig = go.Figure(data=[go.Bar(x=[f"SF{sf}" for sf in sf_dist.keys()], y=list(sf_dist.values()))])
+        categories = [f"SF {sf}" for sf in range(7, 13)]
+        values = [sf_dist.get(sf, 0) for sf in range(7, 13)]
+        fig = go.Figure(data=[go.Bar(x=categories, y=values)])
         fig.update_layout(
             title="Répartition des SF par nœud",
             xaxis_title="SF",
@@ -1194,9 +1196,9 @@ def fast_forward(event=None):
                 callback_interval_indicator.value = 0
                 # Les détails de PDR ne sont pas affichés en direct
                 sf_dist = metrics["sf_distribution"]
-                sf_fig = go.Figure(
-                    data=[go.Bar(x=[f"SF{sf}" for sf in sf_dist.keys()], y=list(sf_dist.values()))]
-                )
+                categories = [f"SF {sf}" for sf in range(7, 13)]
+                values = [sf_dist.get(sf, 0) for sf in range(7, 13)]
+                sf_fig = go.Figure(data=[go.Bar(x=categories, y=values)])
                 sf_fig.update_layout(
                     title="Répartition des SF par nœud",
                     xaxis_title="SF",


### PR DESCRIPTION
## Summary
- Ensure SF histogram uses fixed labels `SF 7`–`SF 12` for x-axis
- Fill missing spreading factors with zero so the graph stays ordered

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893e9e903f483318fefff095ad450a3