### PR TITLE
Supprimer le tableau de comparaison FLoRa du dashboard

### DIFF
--- a/simulateur_lora_sfrd/launcher/dashboard.py
+++ b/simulateur_lora_sfrd/launcher/dashboard.py
@@ -57,7 +57,6 @@ auto_fast_forward = False
 timeline_fig = go.Figure()
 last_event_index = 0
 pause_prev_disabled = False
-flora_metrics = None
 node_paths: dict[int, list[tuple[float, float]]] = {}
 
 # Period for simulation step callback in milliseconds
@@ -292,13 +291,6 @@ fast_forward_progress = pn.indicators.Progress(name="Avancement", value=0, width
 pdr_table = pn.pane.DataFrame(
     pd.DataFrame(columns=["Node", "PDR", "Recent PDR"]),
     height=200,
-    width=220,
-)
-
-# Tableau de comparaison avec FLoRa
-flora_compare_table = pn.pane.DataFrame(
-    pd.DataFrame(columns=["Metric", "FLoRa", "SFRD", "Diff"]),
-    height=180,
     width=220,
 )
 
@@ -627,21 +619,6 @@ def step_simulation():
         }
     )
     pdr_table.object = table_df
-    if flora_metrics:
-        metrics_keys = ["PDR", "collisions", "throughput_bps", "energy_J"]
-        rows = []
-        for key in metrics_keys:
-            flora_val = flora_metrics.get(key, 0)
-            sim_val = metrics.get(key, 0)
-            rows.append(
-                {
-                    "Metric": key,
-                    "FLoRa": flora_val,
-                    "SFRD": sim_val,
-                    "Diff": sim_val - flora_val,
-                }
-            )
-        flora_compare_table.object = pd.DataFrame(rows)
 
     if not cont:
         on_stop(None)
@@ -695,8 +672,6 @@ def setup_simulation(seed_offset: int = 0):
     path_map = None
     terrain_map = None
     dyn_map = None
-    global flora_metrics
-    flora_metrics = None
 
     # Choisir le modèle de mobilité
     mobility_instance = None
@@ -1157,26 +1132,6 @@ def fast_forward(event=None):
                     }
                 )
                 pdr_table.object = table_df
-                if flora_metrics:
-                    metrics_keys = [
-                        "PDR",
-                        "collisions",
-                        "throughput_bps",
-                        "energy_J",
-                    ]
-                    rows = []
-                    for key in metrics_keys:
-                        flora_val = flora_metrics.get(key, 0)
-                        sim_val = metrics.get(key, 0)
-                        rows.append(
-                            {
-                                "Metric": key,
-                                "FLoRa": flora_val,
-                                "SFRD": sim_val,
-                                "Diff": sim_val - flora_val,
-                            }
-                        )
-                    flora_compare_table.object = pd.DataFrame(rows)
                 # Les détails de PDR ne sont pas affichés en direct
                 sf_dist = metrics["sf_distribution"]
                 categories = [f"SF {sf}" for sf in range(7, 13)]
@@ -1371,7 +1326,6 @@ metrics_col = pn.Column(
     energy_indicator,
     throughput_indicator,
     pdr_table,
-    flora_compare_table,
 )
 metrics_col.width = 220
 


### PR DESCRIPTION
## Résumé
- Retire le tableau de comparaison FLoRa/SFRD/Diff du tableau de bord
- Nettoie le code associé à la mise à jour de ce tableau

## Tests
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893ed15deac8331a9850f018ed6aee7