### PR TITLE
refactor: extract correlated value util

### DIFF
--- a/simulateur_lora_sfrd/launcher/advanced_channel.py
+++ b/simulateur_lora_sfrd/launcher/advanced_channel.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import math
 import numpy as np
 
+from .utils.correlated import _CorrelatedValue
+
 
 class _CorrelatedFading:
     """Temporal correlation for Rayleigh/Rician/Nakagami fading."""
@@ -50,29 +52,6 @@ class _CorrelatedFading:
             sum_q += self.q[p]
         amp = math.sqrt(sum_i ** 2 + sum_q ** 2) / self.paths
         return 20 * math.log10(max(amp, 1e-12))
-
-
-class _CorrelatedValue:
-    """Correlated random walk used for drifting offsets."""
-
-    def __init__(
-        self,
-        mean: float,
-        std: float,
-        correlation: float,
-        rng: np.random.Generator | None = None,
-    ) -> None:
-        self.mean = mean
-        self.std = std
-        self.corr = correlation
-        self.value = mean
-        self.rng = rng or np.random.Generator(np.random.MT19937())
-
-    def sample(self) -> float:
-        self.value = self.corr * self.value + (1.0 - self.corr) * self.mean
-        if self.std > 0.0:
-            self.value += self.rng.normal(0.0, self.std)
-        return self.value
 
 
 class AdvancedChannel:

--- a/simulateur_lora_sfrd/launcher/utils/correlated.py
+++ b/simulateur_lora_sfrd/launcher/utils/correlated.py
@@ -1,0 +1,28 @@
+"""Utility classes for correlated random processes."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+class _CorrelatedValue:
+    """Correlated random walk used for drifting offsets."""
+
+    def __init__(
+        self,
+        mean: float,
+        std: float,
+        correlation: float,
+        rng: np.random.Generator | None = None,
+    ) -> None:
+        self.mean = mean
+        self.std = std
+        self.corr = correlation
+        self.value = mean
+        self.rng = rng or np.random.Generator(np.random.MT19937())
+
+    def sample(self) -> float:
+        self.value = self.corr * self.value + (1.0 - self.corr) * self.mean
+        if self.std > 0.0:
+            self.value += self.rng.normal(0.0, self.std)
+        return self.value


### PR DESCRIPTION
## Summary
- extract `_CorrelatedValue` into new utility module
- use new utility in `advanced_channel` and `node`
- avoid creating correlated offset objects when offsets are zero

## Testing
- `pytest tests/test_interval_jitter.py tests/test_rx_windows.py tests/test_min_interval.py tests/test_mobility_extra.py tests/test_impulsive_noise.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689482b47bac8331b2506f88057ce54a