### PR TITLE
Add option to disable channel impairments in ADR1

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,7 +560,7 @@ Pour reproduire un scénario FLoRa :
    (`multipath_taps=3`), un seuil de détection fixé à `-110 dBm` et une fenêtre
    d'interférence minimale de `5 s`. Le délai réseau est également de 10 ms avec
    un traitement serveur de 1,2 s comme dans OMNeT++.
-2. Appliquez l'algorithme ADR1 via `from simulateur_lora_sfrd.launcher.adr_standard_1 import apply as adr1` puis `adr1(sim)`.
+2. Appliquez l'algorithme ADR1 via `from simulateur_lora_sfrd.launcher.adr_standard_1 import apply as adr1` puis `adr1(sim, disable_channel_impairments=False)`.
    Cette fonction reprend la logique du serveur FLoRa original.
 3. Spécifiez `adr_method="avg"` lors de la création du `Simulator` (ou sur
    `sim.network_server`) pour utiliser la moyenne des 20 derniers SNR.

--- a/examples/run_flora_example.py
+++ b/examples/run_flora_example.py
@@ -18,6 +18,6 @@ if __name__ == "__main__":
         seed=1,
         adr_method="avg",
     )
-    adr1(sim)
+    adr1(sim, disable_channel_impairments=False)
     sim.run(1000)
     print(sim.get_metrics())

--- a/simulateur_lora_sfrd/launcher/adr_standard_1.py
+++ b/simulateur_lora_sfrd/launcher/adr_standard_1.py
@@ -5,8 +5,17 @@ from . import server
 from .lorawan import TX_POWER_INDEX_TO_DBM
 
 
-def apply(sim: Simulator) -> None:
-    """Configure ADR variant ``adr_standard_1`` (LoRaWAN defaults)."""
+def apply(sim: Simulator, disable_channel_impairments: bool = True) -> None:
+    """Configure ADR variant ``adr_standard_1`` (LoRaWAN defaults).
+
+    Parameters
+    ----------
+    sim:
+        Simulation instance to update.
+    disable_channel_impairments:
+        When ``True`` (default), reset optional channel impairment parameters
+        such as fading or advanced capture on all channels of the simulator.
+    """
     Simulator.MARGIN_DB = 15.0
     server.MARGIN_DB = Simulator.MARGIN_DB
     sim.adr_node = True
@@ -15,6 +24,41 @@ def apply(sim: Simulator) -> None:
     sim.adr_method = "avg"
     sim.network_server.adr_enabled = True
     sim.network_server.adr_method = "avg"
+    if disable_channel_impairments and getattr(sim, "multichannel", None):
+        impairment_defaults = {
+            "fine_fading_std": 0.0,
+            "variable_noise_std": 0.0,
+            "advanced_capture": False,
+            "flora_capture": False,
+            "fast_fading_std": 0.0,
+            "noise_floor_std": 0.0,
+            "time_variation_std": 0.0,
+            "frequency_offset_hz": 0.0,
+            "freq_offset_std_hz": 0.0,
+            "dev_freq_offset_std_hz": 0.0,
+            "freq_drift_std_hz": 0.0,
+            "clock_drift_std_s": 0.0,
+            "clock_jitter_std_s": 0.0,
+            "temperature_std_K": 0.0,
+            "phase_noise_std_dB": 0.0,
+            "pa_non_linearity_dB": 0.0,
+            "pa_non_linearity_std_dB": 0.0,
+            "pa_ramp_up_s": 0.0,
+            "pa_ramp_down_s": 0.0,
+            "pa_ramp_current_a": 0.0,
+            "humidity_std_percent": 0.0,
+            "humidity_noise_coeff_dB": 0.0,
+            "impulsive_noise_prob": 0.0,
+            "impulsive_noise_dB": 0.0,
+            "adjacent_interference_dB": 0.0,
+            "tx_power_std": 0.0,
+            "interference_dB": 0.0,
+            "band_interference": [],
+        }
+        for ch in sim.multichannel.channels:
+            for attr, val in impairment_defaults.items():
+                if hasattr(ch, attr):
+                    setattr(ch, attr, val)
     for node in sim.nodes:
         node.sf = 12
         node.initial_sf = 12

--- a/simulateur_lora_sfrd/launcher/dashboard.py
+++ b/simulateur_lora_sfrd/launcher/dashboard.py
@@ -773,7 +773,12 @@ def setup_simulation(seed_offset: int = 0):
 
     # Appliquer le profil ADR sélectionné
     if selected_adr_module:
-        selected_adr_module.apply(sim)
+        if selected_adr_module is adr_standard_1:
+            selected_adr_module.apply(
+                sim, disable_channel_impairments=not flora_mode_toggle.value
+            )
+        else:
+            selected_adr_module.apply(sim)
 
     # La mobilité est désormais gérée directement par le simulateur
     start_time = time.time()

--- a/tests/test_flora_sca.py
+++ b/tests/test_flora_sca.py
@@ -19,7 +19,7 @@ def test_flora_sca_compare():
     )
     sca = Path(__file__).parent / "data" / "n100_gw1_expected.sca"
     sim = Simulator(flora_mode=True, config_file=CONFIG, seed=1, adr_method="avg")
-    adr1(sim)
+    adr1(sim, disable_channel_impairments=False)
     sim.run(1000)
     metrics = sim.get_metrics()
 


### PR DESCRIPTION
## Summary
- allow adr_standard_1.apply to reset channel impairments across all channels
- call adr_standard_1.apply with impairment toggle in dashboard when advanced degradation is disabled
- adjust docs, tests and example for new parameter

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689482b8bab88331bd0a14b2df095d56