### PR TITLE
refactor: use list table for ext modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,9 @@ dependencies = [
 where = ["."]
 include = ["simulateur_lora_sfrd*", "traffic*"]
 
-[tool.setuptools.ext-modules]
-flora_cpp = {sources = []}
+[[tool.setuptools.ext-modules]]
+name = "flora_cpp"
+sources = []
 
 [tool.setuptools.cmdclass]
 build_ext = "scripts.flora_ext.BuildFloraExtension"


### PR DESCRIPTION
## Summary
- replace setuptools ext-modules with list table format

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894a263edac8331a17e50551826e78a