### PR TITLE
Use consistent DLL name for Windows

### DIFF
--- a/scripts/build_flora_cpp.ps1
+++ b/scripts/build_flora_cpp.ps1
@@ -31,7 +31,7 @@ if (-not (Test-Path 'src/Makefile')) {
 
 # Build the library using all available cores
 $jobs = [Environment]::ProcessorCount
-& $make 'libflora_phy.so' ("-j$jobs")
+& $make 'libflora_phy.dll' ("-j$jobs")
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-Write-Host "Built library at $(Join-Path $FloraDir 'libflora_phy.so')"
+Write-Host "Built library at $(Join-Path $FloraDir 'libflora_phy.dll')"

--- a/scripts/flora_ext.py
+++ b/scripts/flora_ext.py
@@ -9,16 +9,19 @@ from setuptools.command.build_ext import build_ext
 
 
 class BuildFloraExtension(build_ext):
-    """Custom build_ext to compile the native FLoRa library.
+    """Custom ``build_ext`` to compile the native FLoRa library.
 
-    It simply delegates to the existing shell script then copies the produced
-    ``libflora_phy.so`` into the package directory so it is bundled with the
-    wheel.
+    The build simply delegates to the appropriate script for the current
+    platform and then copies the resulting ``libflora_phy`` shared library into
+    the package directory so it is bundled with the wheel.
     """
 
     def build_extension(self, ext):  # type: ignore[override]
         root = Path(__file__).resolve().parent.parent
         scripts_dir = root / "scripts"
+
+        ext_suffix = "dll" if sys.platform.startswith("win") else "so"
+        lib_name = f"libflora_phy.{ext_suffix}"
 
         if sys.platform.startswith("win"):
             script = scripts_dir / "build_flora_cpp.ps1"
@@ -29,11 +32,9 @@ class BuildFloraExtension(build_ext):
                 "-File",
                 str(script),
             ])
-            lib_name = "libflora_phy.dll"
         else:
             script = scripts_dir / "build_flora_cpp.sh"
             subprocess.check_call(["bash", str(script)])
-            lib_name = "libflora_phy.so"
 
         built = root / "flora-master" / lib_name
         dest = Path(self.build_lib) / "simulateur_lora_sfrd" / "launcher" / lib_name

--- a/simulateur_lora_sfrd/launcher/flora_cpp.py
+++ b/simulateur_lora_sfrd/launcher/flora_cpp.py
@@ -8,10 +8,8 @@ class FloraCppPHY:
     """Wrapper around the native FLoRa physical layer."""
 
     def __init__(self, lib_path: str | None = None) -> None:
-        if sys.platform.startswith("win"):
-            lib_name = "libflora_phy.dll"
-        else:
-            lib_name = "libflora_phy.so"
+        ext_suffix = "dll" if sys.platform.startswith("win") else "so"
+        lib_name = f"libflora_phy.{ext_suffix}"
 
         default_lib = Path(__file__).with_name(lib_name)
         build_error: Exception | None = None

--- a/simulateur_lora_sfrd/launcher/flora_phy.py
+++ b/simulateur_lora_sfrd/launcher/flora_phy.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 import random
 import warnings
+import sys
 
 
 _MISSING_LIB_WARNED = False
@@ -61,9 +62,11 @@ class FloraPHY:
             except OSError:
                 global _MISSING_LIB_WARNED
                 if self.warn_on_fallback and not _MISSING_LIB_WARNED:
+                    ext_suffix = "dll" if sys.platform.startswith("win") else "so"
+                    lib_name = f"libflora_phy.{ext_suffix}"
                     warnings.warn(
                         (
-                            "libflora_phy.so introuvable. "
+                            f"{lib_name} introuvable. "
                             "Utilisation de l'implémentation Python, "
                             "ce qui peut ralentir la simulation. "
                             "Installez le paquet pour compiler automatiquement la bibliothèque"

--- a/tests/test_compare_flora.py
+++ b/tests/test_compare_flora.py
@@ -1,5 +1,6 @@
 import pytest
 from pathlib import Path
+import sys
 
 from simulateur_lora_sfrd.launcher.simulator import Simulator
 from simulateur_lora_sfrd.launcher.compare_flora import (
@@ -174,7 +175,8 @@ def test_flora_full_mode(tmp_path):
             phy_model="flora_full",
         )
     except OSError:
-        pytest.skip("libflora_phy.so missing")
+        lib_name = "libflora_phy.dll" if sys.platform.startswith("win") else "libflora_phy.so"
+        pytest.skip(f"{lib_name} missing")
     sim.run()
     metrics = sim.get_metrics()
     flora = load_flora_metrics(flora_copy)

--- a/tests/test_flora_cpp.py
+++ b/tests/test_flora_cpp.py
@@ -1,4 +1,5 @@
 import pytest
+import sys
 
 from simulateur_lora_sfrd.launcher.channel import Channel
 
@@ -7,7 +8,8 @@ def test_rssi_matches_python_impl():
     try:
         ch_cpp = Channel(phy_model="flora_cpp", shadowing_std=0.0)
     except OSError:
-        pytest.skip("libflora_phy.so missing")
+        lib_name = "libflora_phy.dll" if sys.platform.startswith("win") else "libflora_phy.so"
+        pytest.skip(f"{lib_name} missing")
 
     ch_py = Channel(phy_model="flora_full", shadowing_std=0.0)
 

--- a/tests/test_flora_rssi.py
+++ b/tests/test_flora_rssi.py
@@ -2,6 +2,7 @@ import math
 import pytest
 from simulateur_lora_sfrd.launcher.channel import Channel
 from simulateur_lora_sfrd.launcher.flora_phy import FloraPHY
+import sys
 
 
 def flora_equations(tx_power: float, distance: float, sf: int, ch: Channel):
@@ -56,7 +57,8 @@ def test_channel_compute_rssi_matches_flora_equations():
             frontend_filter_order=0,
         )
     except OSError:
-        pytest.skip("libflora_phy.so missing")
+        lib_name = "libflora_phy.dll" if sys.platform.startswith("win") else "libflora_phy.so"
+        pytest.skip(f"{lib_name} missing")
     ch.shadowing_std = 0.0  # deterministic
     expected_rssi, expected_snr = flora_equations(tx_power, distance, sf, ch)
     rssi, snr = ch.compute_rssi(tx_power, distance, sf=sf)
@@ -77,7 +79,8 @@ def test_oulu_path_loss_model():
             frontend_filter_order=0,
         )
     except OSError:
-        pytest.skip("libflora_phy.so missing")
+        lib_name = "libflora_phy.dll" if sys.platform.startswith("win") else "libflora_phy.so"
+        pytest.skip(f"{lib_name} missing")
     ch.shadowing_std = 0.0
     expected_rssi, expected_snr = oulu_equations(tx_power, distance, sf, ch)
     rssi, snr = ch.compute_rssi(tx_power, distance, sf=sf)

--- a/tests/test_flora_sensitivity.py
+++ b/tests/test_flora_sensitivity.py
@@ -2,6 +2,7 @@ import re
 from pathlib import Path
 
 import pytest
+import sys
 
 from simulateur_lora_sfrd.launcher.channel import Channel
 from simulateur_lora_sfrd.launcher.flora_phy import FloraPHY
@@ -53,7 +54,8 @@ def test_flora_exact_ber_matches_formula():
     try:
         ch = Channel(phy_model="flora_full", shadowing_std=0.0)
     except OSError:
-        pytest.skip("libflora_phy.so missing")
+        lib_name = "libflora_phy.dll" if sys.platform.startswith("win") else "libflora_phy.so"
+        pytest.skip(f"{lib_name} missing")
     phy = FloraPHY(ch, use_exact_ber=True)
 
     per = phy.packet_error_rate(snr, sf, payload)


### PR DESCRIPTION
## Summary
- build Windows C++ library as `libflora_phy.dll`
- derive library name from platform in setup and runtime loaders
- update tests and warnings to skip/use matching library file

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68950e364d98833184d37291a1929cc3