### PR TITLE
Ensure simulation starts with positive workload

### DIFF
--- a/simulateur_lora_sfrd/launcher/dashboard.py
+++ b/simulateur_lora_sfrd/launcher/dashboard.py
@@ -710,10 +710,9 @@ def setup_simulation(seed_offset: int = 0):
 
     # Valider que des paquets ou une durée réelle sont définis
     if int(packets_input.value) <= 0 and float(real_time_duration_input.value) <= 0:
-        export_message.object = (
-            "⚠️ Définissez un nombre de paquets ou une durée réelle supérieurs à 0 !"
+        raise ValueError(
+            "packets_input or real_time_duration_input must be > 0 to schedule events"
         )
-        return
 
     if not _validate_positive_inputs():
         return

--- a/simulateur_lora_sfrd/launcher/tests/test_dashboard_validation.py
+++ b/simulateur_lora_sfrd/launcher/tests/test_dashboard_validation.py
@@ -36,3 +36,11 @@ def test_invalid_area_prevents_start():
     dashboard.on_start(None)
     assert dashboard.sim is None
     assert "⚠️" in dashboard.export_message.object
+
+
+def test_zero_packets_and_duration_raise():
+    reset_inputs()
+    dashboard.packets_input.value = 0
+    dashboard.real_time_duration_input.value = 0.0
+    with pytest.raises(ValueError):
+        dashboard.setup_simulation()


### PR DESCRIPTION
## Summary
- Validate that at least one of `packets_input` or `real_time_duration_input` is strictly positive before setting up a simulation
- Add regression test covering the new validation rule

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68952bfa59048331a102713a014d659b