### PR TITLE
Clarify dependency install and add dashboard install error

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,16 @@ Les principales équations sont décrites dans docs/equations_flora.md.
 
    Ces outils fournissent `make` et un compilateur pour construire la bibliothèque native.
 
-2. **Créez un environnement virtuel et installez le projet :**
+2. **Créez un environnement virtuel, installez les dépendances puis le projet :**
+
+   Les modules `panel`, `plotly`, `numpy` et `pandas` sont nécessaires pour le
+   tableau de bord. Il est recommandé d'installer les dépendances listées dans
+   `requirements.txt` avant de lancer le simulateur :
+
    ```bash
    python3 -m venv env
    source env/bin/activate  # Sous Windows : env\Scripts\activate
+   pip install -r requirements.txt
    pip install -e .
    # ou avec les dépendances de développement :
    pip install -e .[dev]

--- a/simulateur_lora_sfrd/launcher/dashboard.py
+++ b/simulateur_lora_sfrd/launcher/dashboard.py
@@ -18,7 +18,13 @@ def _install_requirements() -> None:
     """
 
     req_file = os.path.join(REPO_ROOT, "requirements.txt")
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "-r", req_file])
+    try:
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "-r", req_file])
+    except subprocess.CalledProcessError as exc:  # pragma: no cover
+        raise RuntimeError(
+            "Failed to install dashboard dependencies. "
+            "Please run 'pip install -r requirements.txt' manually."
+        ) from exc
 
 
 try:  # Les dépendances lourdes sont optionnelles pour pouvoir exécuter les tests sans elles
@@ -31,7 +37,7 @@ try:  # Les dépendances lourdes sont optionnelles pour pouvoir exécuter les te
 except Exception:  # pragma: no cover - utilisé uniquement lorsque dépendances manquantes
     try:
         _install_requirements()
-    except subprocess.CalledProcessError as exc:  # pragma: no cover
+    except Exception as exc:  # pragma: no cover
         raise ImportError("dashboard dependencies not available") from exc
     import panel as pn
     import plotly.graph_objects as go


### PR DESCRIPTION
## Summary
- Document required dashboard modules and recommend `pip install -r requirements.txt`
- Catch install failures in `_install_requirements` and raise descriptive error

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68952c1106c88331a652b0cb5e644290