### PR TITLE
Clarify native DLL location and add manual copy hint

### DIFF
--- a/scripts/build_flora_cpp.ps1
+++ b/scripts/build_flora_cpp.ps1
@@ -34,4 +34,5 @@ $jobs = [Environment]::ProcessorCount
 & $make 'libflora_phy.dll' ("-j$jobs")
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-Write-Host "Built library at $(Join-Path $FloraDir 'libflora_phy.dll')"
+$dllPath = Join-Path $FloraDir 'libflora_phy.dll'
+Write-Host "Build succeeded. DLL available at $dllPath (flora-master/libflora_phy.dll)"

--- a/simulateur_lora_sfrd/launcher/dashboard.py
+++ b/simulateur_lora_sfrd/launcher/dashboard.py
@@ -54,37 +54,46 @@ for path in (ROOT_DIR, REPO_ROOT):
 lib_ext = ".dll" if sys.platform.startswith("win") else ".so"
 lib_name = f"libflora_phy{lib_ext}"
 LIB_FLORA = os.path.join(os.path.dirname(__file__), lib_name)
+flora_dir = os.path.join(REPO_ROOT, "flora-master")
+built = os.path.join(flora_dir, lib_name)
+
 if not os.path.exists(LIB_FLORA):
-    print(f"{lib_name} manquant, compilation...")
-    scripts_dir = os.path.join(REPO_ROOT, "scripts")
-    if sys.platform.startswith("win"):
-        script = os.path.join(scripts_dir, "build_flora_cpp.ps1")
-        cmd = [
-            "powershell",
-            "-NoProfile",
-            "-ExecutionPolicy",
-            "Bypass",
-            "-File",
-            script,
-        ]
+    if os.path.exists(built):
+        print(
+            f"{lib_name} présent dans 'flora-master' mais absent de 'launcher'. "
+            "Copiez-le manuellement pour l'utiliser."
+        )
     else:
-        script = os.path.join(scripts_dir, "build_flora_cpp.sh")
-        cmd = ["bash", script]
-    try:
-        subprocess.run(cmd, check=True)
-    except Exception as exc:  # pragma: no cover - afficher erreur et continuer
-        print(f"Échec de compilation de {lib_name}: {exc}")
-    else:
-        flora_dir = os.path.join(REPO_ROOT, "flora-master")
-        built = os.path.join(flora_dir, lib_name)
-        if not os.path.exists(built):
-            alt_ext = ".dll" if lib_ext == ".so" else ".so"
-            alt_built = os.path.join(flora_dir, f"libflora_phy{alt_ext}")
-            if os.path.exists(alt_built):
-                built = alt_built
-                LIB_FLORA = os.path.join(os.path.dirname(__file__), os.path.basename(built))
-        if os.path.exists(built):
-            shutil.copy2(built, LIB_FLORA)
+        print(f"{lib_name} manquant, compilation...")
+        scripts_dir = os.path.join(REPO_ROOT, "scripts")
+        if sys.platform.startswith("win"):
+            script = os.path.join(scripts_dir, "build_flora_cpp.ps1")
+            cmd = [
+                "powershell",
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                script,
+            ]
+        else:
+            script = os.path.join(scripts_dir, "build_flora_cpp.sh")
+            cmd = ["bash", script]
+        try:
+            subprocess.run(cmd, check=True)
+        except Exception as exc:  # pragma: no cover - afficher erreur et continuer
+            print(f"Échec de compilation de {lib_name}: {exc}")
+        else:
+            if not os.path.exists(built):
+                alt_ext = ".dll" if lib_ext == ".so" else ".so"
+                alt_built = os.path.join(flora_dir, f"libflora_phy{alt_ext}")
+                if os.path.exists(alt_built):
+                    built = alt_built
+                    LIB_FLORA = os.path.join(
+                        os.path.dirname(__file__), os.path.basename(built)
+                    )
+            if os.path.exists(built):
+                shutil.copy2(built, LIB_FLORA)
 
 from launcher.simulator import Simulator  # noqa: E402
 from launcher.channel import Channel  # noqa: E402


### PR DESCRIPTION
## Summary
- Print full path to the generated libflora_phy.dll after successful PowerShell build
- Warn users when the DLL exists in `flora-master` but not in `launcher`, suggesting a manual copy

## Testing
- `pytest` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68952c1584008331a9ae623528564c32