### PR TITLE
Ensure FLoRa library build runs from repo root

### DIFF
--- a/simulateur_lora_sfrd/launcher/dashboard.py
+++ b/simulateur_lora_sfrd/launcher/dashboard.py
@@ -91,7 +91,9 @@ if not os.path.exists(LIB_FLORA):
         script = os.path.join(scripts_dir, "build_flora_cpp.sh")
         cmd = ["bash", script]
     try:
-        subprocess.run(cmd, check=True)
+        # Always run the build from the repository root so the script can
+        # locate ``flora-master`` regardless of the current working directory.
+        subprocess.run(cmd, check=True, cwd=REPO_ROOT)
     except Exception as exc:  # pragma: no cover - afficher erreur et continuer
         msg = f"Échec de compilation de {lib_name}: {exc}"
         print(msg)


### PR DESCRIPTION
## Summary
- Build `libflora_phy` from the repository root when launching the dashboard so the C++ sources are found reliably

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895303d480483318d570471c6b01eb7