### PR TITLE
Install dashboard dependencies on launch

### DIFF
--- a/simulateur_lora_sfrd/launcher/dashboard.py
+++ b/simulateur_lora_sfrd/launcher/dashboard.py
@@ -27,24 +27,17 @@ def _install_requirements() -> None:
         ) from exc
 
 
-try:  # Les dépendances lourdes sont optionnelles pour pouvoir exécuter les tests sans elles
+# Install dashboard dependencies automatically when the module is imported.
+try:  # pragma: no cover - installation or import may fail when deps unavailable
+    _install_requirements()
     import panel as pn
     import plotly.graph_objects as go
     import numpy as np
     import time
     import threading
     import pandas as pd
-except Exception:  # pragma: no cover - utilisé uniquement lorsque dépendances manquantes
-    try:
-        _install_requirements()
-    except Exception as exc:  # pragma: no cover
-        raise ImportError("dashboard dependencies not available") from exc
-    import panel as pn
-    import plotly.graph_objects as go
-    import numpy as np
-    import time
-    import threading
-    import pandas as pd
+except Exception as exc:  # pragma: no cover - fallback when dependencies missing
+    raise ImportError("dashboard dependencies not available") from exc
 
 # Collect alerts for later display in ``metrics_col``
 metrics_col = None


### PR DESCRIPTION
## Summary
- Install Python requirements automatically when the dashboard module is imported
- Raise clear ImportError when dependency installation or import fails

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895335d08548331bb48e0c290677f7f