### PR TITLE
Start dashboard callbacks immediately

### DIFF
--- a/simulateur_lora_sfrd/launcher/dashboard.py
+++ b/simulateur_lora_sfrd/launcher/dashboard.py
@@ -900,7 +900,7 @@ def setup_simulation(seed_offset: int = 0):
             "hist_callback", update_histogram, int(HIST_UPDATE_PERIOD * 1000)
         )
 
-    pn.state.onload(_start_periodic_callbacks)
+    _start_periodic_callbacks()
 
     update_map()
     pdr_indicator.value = 0


### PR DESCRIPTION
## Summary
- start periodic callbacks directly at simulation setup instead of waiting for Panel onload event

## Testing
- `pytest tests/test_dashboard_pause.py tests/test_session_alive_bokeh3.py -q` *(skipped: dashboard dependencies not available)*


------
https://chatgpt.com/codex/tasks/task_e_68953541650c833189fec9bcbe6f6543