### PR TITLE
Improve Windows build tool detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,11 @@ sensiblement plus lente.
 
 ## Windows
 
-- installez `make` ou `mingw32-make` (par exemple via
-  [MinGW-w64](https://www.mingw-w64.org/downloads/) ou
+- installez `nmake` (via les *Visual Studio Build Tools*) ou un `make.exe`
+  (par exemple fourni par [MSYS2](https://www.msys2.org/) ou
   [Chocolatey](https://community.chocolatey.org/packages/make))
+- le script `scripts/build_flora_cpp.ps1` détecte automatiquement l'outil
+  disponible et affiche des conseils d'installation s'il est absent
 - lancez `scripts/build_flora_cpp.ps1` pour générer `libflora_phy.dll`
 - si nécessaire, définissez la variable d'environnement `FLORA_CPP_LIB`
   pour pointer vers votre `libflora_phy.dll`

--- a/scripts/build_flora_cpp.ps1
+++ b/scripts/build_flora_cpp.ps1
@@ -12,16 +12,25 @@ if (-not (Test-Path $FloraDir)) {
 
 Set-Location $FloraDir
 
-# Determine make executable (make or mingw32-make)
-$make = Get-Command make -ErrorAction SilentlyContinue
+# Determine build tool (nmake or make.exe)
+$make = Get-Command nmake -ErrorAction SilentlyContinue
 if (-not $make) {
-    $make = Get-Command mingw32-make -ErrorAction SilentlyContinue
+    $make = Get-Command make -ErrorAction SilentlyContinue
 }
 if (-not $make) {
-    Write-Error "'make' or 'mingw32-make' not found in PATH"
+    $bundledMake = Join-Path $ScriptDir 'make.exe'
+    if (Test-Path $bundledMake) {
+        $make = Get-Item $bundledMake
+    }
+}
+if (-not $make) {
+    Write-Error "No suitable build tool ('nmake' or 'make.exe') found"
+    Write-Host "Install Visual Studio Build Tools (provides nmake) or MSYS2"
+    Write-Host "Chocolatey : choco install make"
+    Write-Host "MSYS2       : pacman -S make"
     exit 1
 }
-$make = $make.Source
+$make = if ($make -is [string]) { $make } else { $make.Source }
 
 # Generate makefiles if missing
 if (-not (Test-Path 'src/Makefile')) {


### PR DESCRIPTION
## Summary
- support `nmake` or bundled `make.exe` in build script
- document Windows prerequisites for native library build

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689539d8021c8331994ea6728a16aaf8