### PR TITLE
Place FLoRa library in launcher and clarify build guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,18 @@ sensiblement plus lente.
 - si nécessaire, définissez la variable d'environnement `FLORA_CPP_LIB`
   pour pointer vers votre `libflora_phy.dll`
 
+Après l'exécution du script (`scripts/build_flora_cpp.sh` sous Linux/macOS ou
+`scripts/build_flora_cpp.ps1` sous Windows), la bibliothèque générée est
+automatiquement copiée dans `simulateur_lora_sfrd/launcher`. Vérifiez que
+`libflora_phy.so` ou `libflora_phy.dll` est bien présent :
+
+```bash
+ls simulateur_lora_sfrd/launcher/libflora_phy.*
+```
+
+Si le fichier est absent, assurez-vous d'avoir installé la chaîne de
+compilation appropriée puis relancez le script.
+
 ## Exemples d'utilisation avancés
 
 Quelques commandes pour tester des scénarios plus complexes :

--- a/scripts/build_flora_cpp.ps1
+++ b/scripts/build_flora_cpp.ps1
@@ -31,8 +31,12 @@ if (-not (Test-Path 'src/Makefile')) {
 
 # Build the library using all available cores
 $jobs = [Environment]::ProcessorCount
-& $make 'libflora_phy.dll' ("-j$jobs")
+$libName = 'libflora_phy.dll'
+& $make $libName ("-j$jobs")
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-$dllPath = Join-Path $FloraDir 'libflora_phy.dll'
-Write-Host "DLL built successfully at $dllPath"
+$dllPath = Join-Path $FloraDir $libName
+$targetDir = Join-Path $RootDir 'simulateur_lora_sfrd/launcher'
+New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
+Copy-Item $dllPath $targetDir -Force
+Write-Host "DLL built and placed in $targetDir\$libName"

--- a/scripts/build_flora_cpp.sh
+++ b/scripts/build_flora_cpp.sh
@@ -21,6 +21,11 @@ if [ ! -f src/Makefile ]; then
     make makefiles
 fi
 
-make libflora_phy.so -j$(nproc)
+LIB_NAME="libflora_phy.so"
+make "$LIB_NAME" -j$(nproc)
 
-echo "Built library at $FLORA_DIR/libflora_phy.so"
+LAUNCHER_DIR="$ROOT_DIR/simulateur_lora_sfrd/launcher"
+mkdir -p "$LAUNCHER_DIR"
+cp "$FLORA_DIR/$LIB_NAME" "$LAUNCHER_DIR/"
+
+echo "Placed library in $LAUNCHER_DIR/$LIB_NAME"

--- a/simulateur_lora_sfrd/launcher/flora_cpp.py
+++ b/simulateur_lora_sfrd/launcher/flora_cpp.py
@@ -60,8 +60,11 @@ class FloraCppPHY:
             msg = f"Impossible de charger {lib_name}"
             if build_error:
                 msg += (
-                    f" (build failed: {build_error}. "
-                    "Install the required toolchain and retry)"
+                    " (compilation failed. Install a C++ toolchain "
+                    "(gcc/make on Linux, Visual Studio Build Tools or MSYS2 on Windows), "
+                    "then run scripts/build_flora_cpp.sh or build_flora_cpp.ps1 to "
+                    "generate the library in simulateur_lora_sfrd/launcher. "
+                    f"Original error: {build_error})"
                 )
             elif last_error:
                 msg += f" ({last_error})"


### PR DESCRIPTION
## Summary
- Copy the compiled libflora_phy library to `simulateur_lora_sfrd/launcher` in both build scripts
- Provide clearer build failure guidance in `flora_cpp.py`
- Document how to build and verify the native library in the README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689539de7d988331903376004ff8cfb6