### PR TITLE
Wrap Panel with_lock callbacks in dashboard and add regression test

### DIFF
--- a/simulateur_lora_sfrd/launcher/dashboard.py
+++ b/simulateur_lora_sfrd/launcher/dashboard.py
@@ -1243,8 +1243,11 @@ def fast_forward(event=None):
                         last = pct
                         if pn.io.with_lock(session_alive):
                             pn.io.with_lock(
-                                doc.add_next_tick_callback,
-                                lambda val=pct: setattr(fast_forward_progress, "value", val),
+                                lambda: doc.add_next_tick_callback(
+                                    lambda val=pct: setattr(
+                                        fast_forward_progress, "value", val
+                                    )
+                                )
                             )
 
             def update_ui():
@@ -1293,9 +1296,9 @@ def fast_forward(event=None):
                 export_button.disabled = False
 
             if pn.io.with_lock(session_alive):
-                pn.io.with_lock(doc.add_next_tick_callback, update_ui)
+                pn.io.with_lock(lambda: doc.add_next_tick_callback(update_ui))
             else:
-                pn.io.with_lock(on_stop, None)
+                pn.io.with_lock(lambda: on_stop(None))
                 pn.io.with_lock(lambda: setattr(export_button, "disabled", False))
 
         threading.Thread(target=run_and_update, daemon=True).start()

--- a/simulateur_lora_sfrd/launcher/tests/test_with_lock_callbacks.py
+++ b/simulateur_lora_sfrd/launcher/tests/test_with_lock_callbacks.py
@@ -1,0 +1,20 @@
+import types
+import pytest
+
+pn = pytest.importorskip("panel")
+pio = pytest.importorskip("panel.io")
+
+
+def test_with_lock_callbacks_no_typeerror(monkeypatch):
+    doc = types.SimpleNamespace(add_next_tick_callback=lambda cb: cb())
+    monkeypatch.setattr(pn.state, "curdoc", doc)
+
+    export_button = types.SimpleNamespace(disabled=True)
+
+    def on_stop(arg):
+        pass
+
+    pio.with_lock(lambda: doc.add_next_tick_callback(lambda val=42: None))
+    pio.with_lock(lambda: doc.add_next_tick_callback(lambda: None))
+    pio.with_lock(lambda: on_stop(None))
+    pio.with_lock(lambda: setattr(export_button, "disabled", False))


### PR DESCRIPTION
## Summary
- Avoid TypeError by wrapping Panel `with_lock` callbacks in lambdas
- Add regression test to ensure callbacks execute without TypeError

## Testing
- `pytest simulateur_lora_sfrd/launcher/tests/test_with_lock_callbacks.py -q`
- `pytest simulateur_lora_sfrd/launcher/tests -q` *(fails: ModuleNotFoundError: No module named 'simulateur_lora_sfrd')*

------
https://chatgpt.com/codex/tasks/task_e_689539e41ec88331bfbbaa6f33af9645