### PR TITLE
Capture cleanup callback on session destruction

### DIFF
--- a/simulateur_lora_sfrd/launcher/dashboard.py
+++ b/simulateur_lora_sfrd/launcher/dashboard.py
@@ -1476,4 +1476,6 @@ dashboard = pn.Row(
     sizing_mode="stretch_width",
 )
 dashboard.servable(title="Simulateur LoRa")
-pn.state.on_session_destroyed(lambda session_context: _cleanup_callbacks())
+pn.state.on_session_destroyed(
+    lambda session_context, _cleanup=_cleanup_callbacks: _cleanup()
+)


### PR DESCRIPTION
## Summary
- capture `_cleanup_callbacks` in session destruction lambda to avoid lost reference

## Testing
- `pytest`
- `timeout 5 panel serve simulateur_lora_sfrd/launcher/dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_68961e2ad640833182761bbe817cb7b2