### PR TITLE
Use direct session checks in fast-forward progress

### DIFF
--- a/simulateur_lora_sfrd/launcher/dashboard.py
+++ b/simulateur_lora_sfrd/launcher/dashboard.py
@@ -1224,7 +1224,7 @@ def fast_forward(event=None):
                     pct = int(sim.packets_sent / total_packets * 100)
                     if pct != last:
                         last = pct
-                        if pn.io.with_lock(session_alive):
+                        if session_alive():
                             pn.io.with_lock(
                                 lambda: doc.add_next_tick_callback(
                                     lambda val=pct: setattr(
@@ -1278,11 +1278,11 @@ def fast_forward(event=None):
                 pause_button.disabled = pause_prev_disabled
                 export_button.disabled = False
 
-            if pn.io.with_lock(session_alive):
+            if session_alive():
                 pn.io.with_lock(lambda: doc.add_next_tick_callback(update_ui))
             else:
-                pn.io.with_lock(lambda: on_stop(None))
-                pn.io.with_lock(lambda: setattr(export_button, "disabled", False))
+                on_stop(None)
+                export_button.disabled = False
 
         threading.Thread(target=run_and_update, daemon=True).start()
 


### PR DESCRIPTION
## Summary
- Avoid unnecessary `pn.io.with_lock` around `session_alive` in fast-forward logic
- Limit `pn.io.with_lock` usage to UI updates via `doc.add_next_tick_callback`

## Testing
- `pytest simulateur_lora_sfrd/launcher/tests/test_with_lock_callbacks.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68961e3560cc8331aa582f6dc5b2b35a